### PR TITLE
feat(echo): deploy via the home-operations/echo Helm chart

### DIFF
--- a/kubernetes/apps/base/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/echo/helmrelease.yaml
@@ -8,86 +8,43 @@ spec:
   chartRef:
     kind: OCIRepository
     name: echo
-  install:
-    crds: CreateReplace
   interval: 1h
   rollback:
     cleanupOnFail: true
   upgrade:
     cleanupOnFail: true
-    crds: CreateReplace
     strategy:
       name: RemediateOnFailure
     remediation:
       remediateLastFailure: true
       retries: 2
   values:
-    controllers:
-      echo:
-        replicas: 3
-        strategy: RollingUpdate
-        rollingUpdate:
-          surge: "0%"
-          unavailable: 1
-        containers:
-          app:
-            image:
-              repository: ghcr.io/mendhak/http-https-echo
-              tag: 40
-            env:
-              HTTP_PORT: &port 8080
-              LOG_WITHOUT_NEWLINE: true
-              LOG_IGNORE_PATH: /healthz
-              PROMETHEUS_ENABLED: true
-            probes:
-              liveness: &probes
-                enabled: true
-                custom: true
-                spec:
-                  httpGet:
-                    path: /healthz
-                    port: *port
-                  initialDelaySeconds: 0
-                  periodSeconds: 10
-                  timeoutSeconds: 1
-                  failureThreshold: 3
-              readiness: *probes
-            securityContext:
-              allowPrivilegeEscalation: false
-              readOnlyRootFilesystem: true
-              capabilities: {drop: ["ALL"]}
-            resources:
-              requests:
-                cpu: 10m
-              limits:
-                memory: 64Mi
-    defaultPodOptions:
-      securityContext:
-        runAsNonRoot: true
-        runAsUser: 1000
-        runAsGroup: 1000
-      topologySpreadConstraints:
-        - maxSkew: 1
-          topologyKey: kubernetes.io/hostname
-          whenUnsatisfiable: DoNotSchedule
-          labelSelector:
-            matchLabels:
-              app.kubernetes.io/name: echo
-              app.kubernetes.io/instance: echo
-    service:
-      app:
-        ports:
-          http:
-            port: *port
-    serviceMonitor:
-      app:
-        endpoints:
-          - port: http
-    route:
-      app:
-        hostnames:
-          - echo.${APP_DOMAIN}
-          - echo.${ALT_DOMAIN}
-        parentRefs:
-          - name: envoy
-            namespace: envoy-system
+    replicaCount: 3
+    config:
+      kubernetes: true
+      trustedProxies:
+        - 10.244.0.0/16
+    httpRoute:
+      enabled: true
+      hostnames:
+        - echo.${APP_DOMAIN}
+        - echo.${ALT_DOMAIN}
+      parentRefs:
+        - name: envoy
+          namespace: envoy-system
+    monitoring:
+      serviceMonitor:
+        enabled: true
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi
+    topologySpreadConstraints:
+      - maxSkew: 1
+        topologyKey: kubernetes.io/hostname
+        whenUnsatisfiable: ScheduleAnyway
+        labelSelector:
+          matchLabels:
+            app.kubernetes.io/name: echo
+            app.kubernetes.io/instance: echo

--- a/kubernetes/apps/base/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/echo/helmrelease.yaml
@@ -35,11 +35,6 @@ spec:
     monitoring:
       serviceMonitor:
         enabled: true
-    resources:
-      requests:
-        cpu: 10m
-      limits:
-        memory: 64Mi
     topologySpreadConstraints:
       - maxSkew: 1
         topologyKey: kubernetes.io/hostname
@@ -48,3 +43,8 @@ spec:
           matchLabels:
             app.kubernetes.io/name: echo
             app.kubernetes.io/instance: echo
+    resources:
+      requests:
+        cpu: 10m
+      limits:
+        memory: 64Mi

--- a/kubernetes/apps/base/echo/ocirepository.yaml
+++ b/kubernetes/apps/base/echo/ocirepository.yaml
@@ -10,5 +10,5 @@ spec:
     mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
     operation: copy
   ref:
-    tag: 4.6.2
-  url: oci://ghcr.io/bjw-s-labs/helm/app-template
+    tag: 0.1.2
+  url: oci://ghcr.io/home-operations/charts/echo

--- a/kubernetes/apps/production/default/echo.yaml
+++ b/kubernetes/apps/production/default/echo.yaml
@@ -30,8 +30,8 @@ spec:
           name: echo
         spec:
           ref:
-            # renovate: datasource=docker depName=ghcr.io/bjw-s-labs/helm/app-template
-            tag: 4.6.2
+            # renovate: datasource=docker depName=ghcr.io/home-operations/charts/echo
+            tag: 0.1.2
       target:
         kind: OCIRepository
         name: echo


### PR DESCRIPTION
## What

Moves the `echo` app onto the dedicated [home-operations/echo](https://github.com/home-operations/echo) OCI Helm chart, replacing the bjw-s `app-template` deployment of `ghcr.io/mendhak/http-https-echo`.

Modeled on the [onedr0p/home-ops reference deployment](https://github.com/onedr0p/home-ops/tree/main/kubernetes/apps/network/echo).

## Changes

- **`base/echo/ocirepository.yaml`** — points at `oci://ghcr.io/home-operations/charts/echo` (`0.1.2`) instead of the app-template chart.
- **`base/echo/helmrelease.yaml`** — uses the echo chart's native values (`replicaCount`, `config`, `httpRoute`, `monitoring`) in place of the app-template schema. The chart ships secure defaults (non-root uid/gid 65532, read-only root fs, drop ALL caps, probes on `/healthz`), so the manual `securityContext`/`probes`/`env` scaffolding is gone. Also drops the no-op `crds: CreateReplace` (echo has no CRDs), matching the `cloudnative-pg` / `descheduler` HelmRelease convention.
- **`production/default/echo.yaml`** — updates the renovate-pinned tag patch to track the new chart.

## Preserved

- HTTPRoute to the `envoy` gateway (`envoy-system`) on `echo.${APP_DOMAIN}` / `echo.${ALT_DOMAIN}`
- ServiceMonitor, 3 replicas, the production version pin (staging stays unpinned)

## Notes

- `config.kubernetes: true` surfaces pod/namespace/IP/node in the echo JSON via the Downward API (matches the reference; flip to `false` to hide cluster topology from callers).
- `config.trustedProxies` is set to the pod CIDR (`10.244.0.0/16`) so echo trusts the Envoy data plane's `X-Forwarded-For`.

## Validation

- `helm template` against `oci://ghcr.io/home-operations/charts/echo:0.1.2` with these values renders the Deployment/Service/HTTPRoute/ServiceMonitor and passes the chart's `values.schema.json`.
- `kustomize build kubernetes/apps/base/echo` renders cleanly.