### PR TITLE
feat: add victoria-logs cluster and collector

### DIFF
--- a/kubernetes/apps/base/grafana-postgres/cluster.yaml
+++ b/kubernetes/apps/base/grafana-postgres/cluster.yaml
@@ -15,7 +15,7 @@ spec:
 
   storage:
     size: 20Gi
-    storageClass: openebs-spare-disk
+    storageClass: openebs-system-disk
 
   # One instance per worker (3 workers, 3 instances).
   affinity:

--- a/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
@@ -1,0 +1,44 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs-collector
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: victoria-logs-collector
+  interval: 1h
+  rollback:
+    cleanupOnFail: true
+  upgrade:
+    cleanupOnFail: true
+    strategy:
+      name: RemediateOnFailure
+    remediation:
+      remediateLastFailure: true
+      retries: 2
+  values:
+    fullnameOverride: victoria-logs-collector
+
+    remoteWrite:
+      - url: http://victoria-logs-vlinsert.o11y.svc.cluster.local:9481/insert/native
+        maxDiskUsagePerURL: 10GB
+
+    extraArgs:
+      "kubernetesCollector.decolorizeFields": _msg
+
+    collector:
+      streamFields:
+        - kubernetes.pod_name
+        - kubernetes.pod_namespace
+        - kubernetes.container_name
+        - kubernetes.pod_labels.app.kubernetes.io/name
+
+    podMonitor:
+      enabled: true
+
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes/apps/base/victoria-logs-collector/kustomization.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/victoria-logs-collector/ocirepository.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs-collector
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.3.6
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/kubernetes/apps/base/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs/helmrelease.yaml
@@ -1,0 +1,60 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: victoria-logs
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: victoria-logs
+  interval: 1h
+  rollback:
+    cleanupOnFail: true
+  upgrade:
+    cleanupOnFail: true
+    strategy:
+      name: RemediateOnFailure
+    remediation:
+      remediateLastFailure: true
+      retries: 2
+  values:
+    fullnameOverride: victoria-logs
+
+    vlstorage:
+      replicaCount: 3
+      retentionPeriod: ${LOGS_RETENTION_PERIOD}
+      persistentVolume:
+        storageClassName: ${LOGS_STORAGE_CLASS}
+        size: 100Gi
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: vlstorage
+      vmServiceScrape:
+        enabled: true
+
+    vlinsert:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: vlinsert
+      vmServiceScrape:
+        enabled: true
+
+    vlselect:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app.kubernetes.io/component: vlselect
+      vmServiceScrape:
+        enabled: true

--- a/kubernetes/apps/base/victoria-logs/kustomization.yaml
+++ b/kubernetes/apps/base/victoria-logs/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./helmrelease.yaml
+  - ./ocirepository.yaml

--- a/kubernetes/apps/base/victoria-logs/ocirepository.yaml
+++ b/kubernetes/apps/base/victoria-logs/ocirepository.yaml
@@ -1,0 +1,14 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/source.toolkit.fluxcd.io/ocirepository_v1.json
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: victoria-logs
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 0.2.7
+  url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-cluster

--- a/kubernetes/apps/base/victoria-metrics-users/vmuser-remote-clusters.yaml
+++ b/kubernetes/apps/base/victoria-metrics-users/vmuser-remote-clusters.yaml
@@ -31,3 +31,11 @@ spec:
         url: http://vminsert-victoria-metrics.o11y.svc.cluster.local:8480
       paths:
         - /insert/0/.*
+    - static:
+        url: http://victoria-logs-vlinsert.o11y.svc.cluster.local:9481
+      paths:
+        - /insert/jsonline
+        - /insert/native
+        - /insert/elasticsearch/.*
+        - /insert/loki/.*
+        - /insert/opentelemetry/.*

--- a/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
     vmcluster:
       enabled: true
       spec:
-        retentionPeriod: 30d
+        retentionPeriod: ${METRICS_RETENTION_PERIOD}
         replicationFactor: 2
         vmstorage:
           replicaCount: 3
@@ -137,6 +137,7 @@ spec:
         httpRoute:
           hostnames:
             - vmauth.${APP_DOMAIN}
+            - vmauth.${ALT_DOMAIN}
           parentRefs:
             - name: envoy
               namespace: envoy-system

--- a/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
@@ -24,6 +24,11 @@ spec:
     global:
       clusterLabel: cluster
 
+    victoria-metrics-operator:
+      env:
+        - name: VM_GATEWAY_API_ENABLED
+          value: "true"
+
     vmcluster:
       enabled: true
       spec:

--- a/kubernetes/apps/production/o11y/kustomization.yaml
+++ b/kubernetes/apps/production/o11y/kustomization.yaml
@@ -9,4 +9,6 @@ resources:
   - ./grafana.yaml
   - ./victoria-metrics.yaml
   - ./victoria-metrics-users.yaml
+  - ./victoria-logs.yaml
+  - ./victoria-logs-collector.yaml
   - ./namespace.yaml

--- a/kubernetes/apps/production/o11y/victoria-logs-collector.yaml
+++ b/kubernetes/apps/production/o11y/victoria-logs-collector.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs-collector
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: victoria-logs
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: victoria-logs-collector
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/base/victoria-logs-collector
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  patches:
+    - patch: |-
+        apiVersion: source.toolkit.fluxcd.io/v1
+        kind: OCIRepository
+        metadata:
+          name: victoria-logs-collector
+        spec:
+          ref:
+            # renovate: datasource=docker depName=ghcr.io/victoriametrics/helm-charts/victoria-logs-collector
+            tag: 0.3.6
+      target:
+        kind: OCIRepository
+        name: victoria-logs-collector

--- a/kubernetes/apps/production/o11y/victoria-logs.yaml
+++ b/kubernetes/apps/production/o11y/victoria-logs.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: victoria-metrics
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: victoria-logs
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/base/victoria-logs
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y
+  patches:
+    - patch: |-
+        apiVersion: source.toolkit.fluxcd.io/v1
+        kind: OCIRepository
+        metadata:
+          name: victoria-logs
+        spec:
+          ref:
+            # renovate: datasource=docker depName=ghcr.io/victoriametrics/helm-charts/victoria-logs-cluster
+            tag: 0.2.7
+      target:
+        kind: OCIRepository
+        name: victoria-logs

--- a/kubernetes/apps/staging/o11y/kustomization.yaml
+++ b/kubernetes/apps/staging/o11y/kustomization.yaml
@@ -9,4 +9,6 @@ resources:
   - ./grafana.yaml
   - ./victoria-metrics.yaml
   - ./victoria-metrics-users.yaml
+  - ./victoria-logs.yaml
+  - ./victoria-logs-collector.yaml
   - ./namespace.yaml

--- a/kubernetes/apps/staging/o11y/victoria-logs-collector.yaml
+++ b/kubernetes/apps/staging/o11y/victoria-logs-collector.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs-collector
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: victoria-logs
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: victoria-logs-collector
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/base/victoria-logs-collector
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y

--- a/kubernetes/apps/staging/o11y/victoria-logs.yaml
+++ b/kubernetes/apps/staging/o11y/victoria-logs.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: victoria-logs
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: victoria-metrics
+  healthChecks:
+    - apiVersion: helm.toolkit.fluxcd.io/v2
+      kind: HelmRelease
+      name: victoria-logs
+      namespace: o11y
+  interval: 1h
+  path: ./kubernetes/apps/base/victoria-logs
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: o11y

--- a/kubernetes/clusters/production/cluster-settings.yaml
+++ b/kubernetes/clusters/production/cluster-settings.yaml
@@ -9,3 +9,6 @@ data:
   ALT_DOMAIN: futostatus.com
   CLUSTER_NAME: o11y-production
   OP_VAULT: o11y_tf_prod
+  LOGS_RETENTION_PERIOD: 120d
+  LOGS_STORAGE_CLASS: openebs-spare-disk-2
+  METRICS_RETENTION_PERIOD: 120d

--- a/kubernetes/clusters/staging/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/cluster-settings.yaml
@@ -9,3 +9,6 @@ data:
   ALT_DOMAIN: staging.futostatus.com
   CLUSTER_NAME: o11y-staging
   OP_VAULT: o11y_tf_staging
+  LOGS_RETENTION_PERIOD: 30d
+  LOGS_STORAGE_CLASS: openebs-spare-disk
+  METRICS_RETENTION_PERIOD: 30d


### PR DESCRIPTION
- Adds vlog cluster
- Adds vlog collector
- Switches postgres to system-disk for prod and stage (needs to be manually addressed after merge)
- Stage metrics and logs live on single spare disk, retention set to 30d
- Prod metrics and logs live on their own spare disk, retention set to 120d