### PR TITLE
feat: mesh egress to bootstrap 1Password Connect + cluster mesh DNS

### DIFF
--- a/deployment/modules/kubernetes/helm/bootstrap-settings.tf
+++ b/deployment/modules/kubernetes/helm/bootstrap-settings.tf
@@ -1,0 +1,19 @@
+# TF-owned values consumed by Flux via postBuild substituteFrom (kubernetes/clusters/
+# <env>/apps.yaml) — single source for anything both TF and the manifests need.
+resource "kubernetes_config_map_v1" "bootstrap_settings" {
+  depends_on = [helm_release.flux_operator]
+
+  metadata {
+    name      = "bootstrap-settings"
+    namespace = "flux-system"
+  }
+
+  data = {
+    BOOTSTRAP_MESH_DOMAIN          = var.netbird.mesh_dns_zone
+    BOOTSTRAP_NETBIRD_GATEWAY_VIP  = var.netbird.gateway_vip
+    BOOTSTRAP_NETBIRD_SERVICE_CIDR = var.netbird.service_cidr
+    BOOTSTRAP_NETBIRD_EGRESS_CIDR  = var.netbird.egress_cidr
+    BOOTSTRAP_NETBIRD_EGRESS_GW    = cidrhost(var.netbird.egress_cidr, 1)
+    BOOTSTRAP_NETBIRD_DNS_IP       = local.netbird_dns_ip
+  }
+}

--- a/deployment/modules/kubernetes/helm/coredns.tf
+++ b/deployment/modules/kubernetes/helm/coredns.tf
@@ -1,0 +1,95 @@
+# TF-seeded, not Flux-managed: Flux needs cluster DNS for external fetches AND for
+# controller->controller artifact URLs, so a fresh bootstrap would deadlock if Flux
+# installed it. Talos's CoreDNS is disabled in talos/cluster.
+locals {
+  # netbird-dns Service pin; published to Flux via bootstrap-settings.
+  netbird_dns_ip = "10.96.0.53"
+}
+
+resource "helm_release" "coredns" {
+  name            = "coredns"
+  namespace       = "kube-system"
+  repository      = "oci://ghcr.io/coredns/charts"
+  chart           = "coredns"
+  version         = var.coredns_version
+  cleanup_on_fail = true
+  # Adopts the same-named Talos coredns objects in place on a live cluster.
+  take_ownership = true
+
+  values = [<<-YAML
+    fullnameOverride: coredns
+    image:
+      repository: mirror.gcr.io/coredns/coredns
+    replicaCount: 2
+    k8sAppLabelOverride: kube-dns
+    priorityClassName: system-cluster-critical
+    # Selectors pinned to the Talos originals: Deployment selectors are immutable, and an
+    # identical Service selector makes adoption a plain rolling update (no empty endpoints).
+    deployment:
+      selector:
+        matchLabels:
+          k8s-app: kube-dns
+    service:
+      name: kube-dns
+      clusterIP: 10.96.0.10
+      selector:
+        k8s-app: kube-dns
+    tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  k8s-app: kube-dns
+    servers:
+      - zones:
+          - zone: .
+        port: 53
+        plugins:
+          - name: errors
+          - name: health
+            configBlock: |-
+              lameduck 5s
+          - name: ready
+          - name: log
+            parameters: .
+            configBlock: |-
+              class error
+          - name: prometheus
+            parameters: 0.0.0.0:9153
+          - name: kubernetes
+            parameters: cluster.local in-addr.arpa ip6.arpa
+            configBlock: |-
+              pods insecure
+              fallthrough in-addr.arpa ip6.arpa
+              ttl 30
+          - name: forward
+            parameters: . /etc/resolv.conf
+            configBlock: |-
+              max_concurrent 1000
+          - name: cache
+            parameters: 30
+            configBlock: |-
+              disable success cluster.local
+              disable denial cluster.local
+          - name: loop
+          - name: reload
+          - name: loadbalance
+      - zones:
+          - zone: futo.network
+        port: 53
+        plugins:
+          - name: errors
+          - name: cache
+            parameters: 30
+          - name: forward
+            parameters: . ${local.netbird_dns_ip}
+    YAML
+  ]
+}

--- a/deployment/modules/kubernetes/helm/helm.tf
+++ b/deployment/modules/kubernetes/helm/helm.tf
@@ -7,6 +7,7 @@ resource "helm_release" "flux_operator" {
   create_namespace = true
   cleanup_on_fail  = true
   wait_for_jobs    = true
+  depends_on       = [helm_release.coredns]
 }
 
 resource "helm_release" "flux_instance" {

--- a/deployment/modules/kubernetes/helm/terragrunt.hcl
+++ b/deployment/modules/kubernetes/helm/terragrunt.hcl
@@ -34,14 +34,24 @@ dependency "netbird" {
 
   mock_outputs = {
     k8s_routing_peer_setup_key = "mock"
+    mesh_dns_zone              = "mock.futo.network"
+    gateway_vip                = "10.0.0.10"
+    service_cidr               = "10.0.0.0/24"
+    egress_cidr                = "10.0.1.0/24"
   }
   mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
   mock_outputs_merge_strategy_with_state  = "shallow"
 }
 
 inputs = {
-  cluster                             = dependency.talos.outputs.cluster
-  netbird_k8s_routing_peer_setup_key  = dependency.netbird.outputs.k8s_routing_peer_setup_key
+  cluster                            = dependency.talos.outputs.cluster
+  netbird_k8s_routing_peer_setup_key = dependency.netbird.outputs.k8s_routing_peer_setup_key
+  netbird = {
+    mesh_dns_zone = dependency.netbird.outputs.mesh_dns_zone
+    gateway_vip   = dependency.netbird.outputs.gateway_vip
+    service_cidr  = dependency.netbird.outputs.service_cidr
+    egress_cidr   = dependency.netbird.outputs.egress_cidr
+  }
 }
 
 generate "backend" {

--- a/deployment/modules/kubernetes/helm/variables.tf
+++ b/deployment/modules/kubernetes/helm/variables.tf
@@ -25,6 +25,11 @@ variable "flux_operator_version" {
   default = "0.50.0"
 }
 
+variable "coredns_version" {
+  type    = string
+  default = "1.46.0"
+}
+
 variable "ovh_application_key" {
   type      = string
   sensitive = true
@@ -58,4 +63,14 @@ variable "op_connect_token_env" {
 variable "netbird_k8s_routing_peer_setup_key" {
   type      = string
   sensitive = true
+}
+
+# TF-owned network values from netbird/cluster, published to Flux via bootstrap-settings.
+variable "netbird" {
+  type = object({
+    mesh_dns_zone = string
+    gateway_vip   = string
+    service_cidr  = string
+    egress_cidr   = string
+  })
 }

--- a/deployment/modules/netbird/cluster/netbird.tf
+++ b/deployment/modules/netbird/cluster/netbird.tf
@@ -86,8 +86,9 @@ resource "netbird_policy" "yucca_to_o11y_resource" {
 locals {
   mesh_dns_zone = var.env == "production" ? "o11y.futo.network" : "${var.env}.o11y.futo.network"
 
-  # NetBox-allocated VIP; must equal the NETBIRD_GATEWAY_VIP cluster-setting.
-  netbird_gateway_vip = var.env == "production" ? "10.69.0.10" : "10.69.1.10"
+  # NetBox-allocated; published to Flux via the bootstrap-settings ConfigMap.
+  netbird_service_cidr = var.env == "production" ? "10.69.0.0/24" : "10.69.1.0/24"
+  netbird_gateway_vip  = cidrhost(local.netbird_service_cidr, 10)
 }
 
 resource "netbird_group" "k8s_routing_peers" {
@@ -131,13 +132,14 @@ resource "netbird_setup_key" "k8s_routing_peer" {
   usage_limit    = 0
 }
 
-# DNS zone; must match the MESH_DOMAIN cluster-setting.
+# Distributed to the router pods too — they serve NetBird DNS to the cluster
+# (CoreDNS forwards futo.network).
 resource "netbird_dns_zone" "mesh" {
   name                 = local.mesh_dns_zone
   domain               = local.mesh_dns_zone
   enabled              = true
   enable_search_domain = false
-  distribution_groups  = [data.netbird_group.yucca.id]
+  distribution_groups  = [data.netbird_group.yucca.id, netbird_group.k8s_routing_peers.id]
 }
 
 # Wildcard A -> the gateway VIP (HA is the >=2 routing Pods, not multiple records).
@@ -162,6 +164,59 @@ resource "netbird_policy" "yucca_to_k8s_gateway" {
     bidirectional = false
     sources       = [data.netbird_group.yucca.id]
     destinations  = [netbird_group.k8s_gateway.id]
+    ports         = ["443"]
+  }
+}
+
+# opc egress: pods with a Multus leg in this range (netbird-egress NAD) reach the bootstrap
+# 1Password Connect. The nodes advertise it, so NetBird's own rules masquerade it out wt0 —
+# pod-CIDR traffic would be dropped.
+locals {
+  # NetBox-allocated. Published to Flux via the bootstrap-settings ConfigMap.
+  netbird_egress_cidr = var.env == "production" ? "10.69.2.0/24" : "10.69.3.0/24"
+}
+
+resource "netbird_network" "k8s_egress" {
+  name        = "O11Y_${upper(var.env)}_K8S_EGRESS"
+  description = "o11y ${var.env} pod egress range (Multus netbird-egress NAD)"
+}
+
+resource "netbird_network_router" "k8s_egress" {
+  network_id  = netbird_network.k8s_egress.id
+  peer_groups = [netbird_group.talos.id]
+  masquerade  = true
+  metric      = 9999
+  enabled     = true
+}
+
+# In o11y_resource: NetBird only programs routers for resources a policy references
+# (a policy-less group left every node unprogrammed). The yucca 50000/6443 grant is inert here.
+resource "netbird_network_resource" "k8s_egress" {
+  network_id = netbird_network.k8s_egress.id
+  name       = "O11Y_${upper(var.env)}_K8S_EGRESS_CIDR"
+  address    = local.netbird_egress_cidr
+  groups     = [netbird_group.o11y_resource.id]
+  enabled    = true
+}
+
+# Bootstrap-owned group holding the opc resource (live account name — verify if it changes).
+data "netbird_group" "bootstrap_opc" {
+  name = "bootstrap-resources"
+}
+
+# Egress leaves masqueraded as the node peer -> nodes are the source; also pushes them the opc /32 route.
+resource "netbird_policy" "talos_to_bootstrap_opc" {
+  name    = "O11Y_${upper(var.env)}_TALOS_TO_BOOTSTRAP_OPC"
+  enabled = true
+
+  rule {
+    name          = "TALOS_TO_BOOTSTRAP_OPC"
+    action        = "accept"
+    protocol      = "tcp"
+    enabled       = true
+    bidirectional = false
+    sources       = [netbird_group.talos.id]
+    destinations  = [data.netbird_group.bootstrap_opc.id]
     ports         = ["443"]
   }
 }

--- a/deployment/modules/netbird/cluster/outputs.tf
+++ b/deployment/modules/netbird/cluster/outputs.tf
@@ -10,3 +10,20 @@ output "k8s_routing_peer_setup_key" {
   sensitive = true
   value     = netbird_setup_key.k8s_routing_peer.key
 }
+
+# Consumed by kubernetes/helm -> bootstrap-settings ConfigMap (Flux substitution).
+output "mesh_dns_zone" {
+  value = local.mesh_dns_zone
+}
+
+output "gateway_vip" {
+  value = local.netbird_gateway_vip
+}
+
+output "service_cidr" {
+  value = local.netbird_service_cidr
+}
+
+output "egress_cidr" {
+  value = local.netbird_egress_cidr
+}

--- a/deployment/modules/talos/cluster/controlplane.tf
+++ b/deployment/modules/talos/cluster/controlplane.tf
@@ -46,6 +46,8 @@ resource "talos_machine_configuration_apply" "controlplane" {
           nodeIP = {
             validSubnets = [var.private_network_cidr]
           }
+          # Explicit: Talos CoreDNS is disabled; the TF-seeded chart keeps this Service IP.
+          clusterDNS = ["10.96.0.10"]
         }
         network = {
           interfaces = [
@@ -66,6 +68,11 @@ resource "talos_machine_configuration_apply" "controlplane" {
       }
       cluster = {
         allowSchedulingOnControlPlanes = false
+        # CoreDNS is TF-seeded (kubernetes/helm): Flux needs DNS before it can install
+        # anything, and disabling Talos's copy keeps upgrade-k8s off the Corefile.
+        coreDNS = {
+          disabled = true
+        }
         # Control-plane components bind their metrics to localhost by default, so
         # VMAgent (on a worker) can't scrape them. Bind to all interfaces; the
         # Talos ingress firewall below keeps the ports private (vRack + pod CIDR

--- a/deployment/modules/talos/cluster/workers.tf
+++ b/deployment/modules/talos/cluster/workers.tf
@@ -41,6 +41,15 @@ resource "talos_machine_configuration_apply" "worker" {
             TOML
           }
         ]
+        # Pin the kubelet node IP to the vRack (CPs already do): kubelet otherwise picks the
+        # lowest 10.x host address — the Multus bridge IP once stole a worker's InternalIP.
+        kubelet = {
+          nodeIP = {
+            validSubnets = [var.private_network_cidr]
+          }
+          # Explicit because Talos's CoreDNS is disabled (see controlplane.tf).
+          clusterDNS = ["10.96.0.10"]
+        }
         network = {
           # NIC names aren't uniform across OVH workers (even within a plan code),
           # so they're per-node via var.worker_nics. Port 0 = public (DHCP),

--- a/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
+++ b/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
@@ -27,7 +27,7 @@ spec:
     onepassword:
       connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
       vaults:
-        ${OP_O11Y_VAULT}: 1
+        ${CLUSTER_OP_O11Y_VAULT}: 1
       auth:
         secretRef:
           connectTokenSecretRef:
@@ -63,7 +63,7 @@ spec:
     onepassword:
       connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
       vaults:
-        ${OP_SHARED_VAULT}: 1
+        ${CLUSTER_OP_SHARED_VAULT}: 1
       auth:
         secretRef:
           connectTokenSecretRef:

--- a/kubernetes/apps/base/echo/helmrelease.yaml
+++ b/kubernetes/apps/base/echo/helmrelease.yaml
@@ -27,7 +27,7 @@ spec:
     httpRoute:
       enabled: true
       hostnames:
-        - echo.${APP_DOMAIN}
+        - echo.${CLUSTER_APP_DOMAIN}
       parentRefs:
         - name: envoy
           namespace: envoy-system

--- a/kubernetes/apps/base/envoy-gateway/certificate.yaml
+++ b/kubernetes/apps/base/envoy-gateway/certificate.yaml
@@ -6,8 +6,8 @@ metadata:
   name: futostatus-com
 spec:
   dnsNames:
-    - "*.${APP_DOMAIN}"
-    - "${APP_DOMAIN}"
+    - "*.${CLUSTER_APP_DOMAIN}"
+    - "${CLUSTER_APP_DOMAIN}"
   duration: 160h
   privateKey:
     algorithm: ECDSA

--- a/kubernetes/apps/base/external-secrets/helmrelease.yaml
+++ b/kubernetes/apps/base/external-secrets/helmrelease.yaml
@@ -22,5 +22,8 @@ spec:
       remediateLastFailure: true
       retries: 2
   values:
+    # Resolve DNS via the CoreDNS futo.network zone
+    podAnnotations:
+      k8s.v1.cni.cncf.io/networks: kube-system/netbird-egress
     serviceMonitor:
       enabled: true

--- a/kubernetes/apps/base/grafana/grafana.yaml
+++ b/kubernetes/apps/base/grafana/grafana.yaml
@@ -44,7 +44,7 @@ spec:
       angular_support_enabled: "true"
     server:
       enable_gzip: "true"
-      root_url: https://grafana.${APP_DOMAIN}
+      root_url: https://grafana.${CLUSTER_APP_DOMAIN}
     database:
       type: postgres
       host: grafana-postgres-rw.o11y.svc.cluster.local:5432
@@ -110,7 +110,7 @@ spec:
   httpRoute:
     spec:
       hostnames:
-        - grafana.${APP_DOMAIN}
+        - grafana.${CLUSTER_APP_DOMAIN}
       parentRefs:
         - name: envoy
           namespace: envoy-system

--- a/kubernetes/apps/base/mesh-gateway-network/servicecidr.yaml
+++ b/kubernetes/apps/base/mesh-gateway-network/servicecidr.yaml
@@ -1,10 +1,10 @@
 ---
 # Secondary ServiceCIDR (k8s 1.33+) holding the gateway VIP — a NetBox-allocated range,
-# globally unique on the shared NetBird account. Must contain NETBIRD_GATEWAY_VIP.
+# globally unique on the shared NetBird account. TF-published via bootstrap-settings.
 apiVersion: networking.k8s.io/v1
 kind: ServiceCIDR
 metadata:
   name: netbird-gateway
 spec:
   cidrs:
-    - ${NETBIRD_SERVICE_CIDR}
+    - ${BOOTSTRAP_NETBIRD_SERVICE_CIDR}

--- a/kubernetes/apps/base/mesh-gateway/certificate.yaml
+++ b/kubernetes/apps/base/mesh-gateway/certificate.yaml
@@ -8,8 +8,8 @@ metadata:
   name: o11y-futo-network
 spec:
   dnsNames:
-    - "*.${MESH_DOMAIN}"
-    - "${MESH_DOMAIN}"
+    - "*.${BOOTSTRAP_MESH_DOMAIN}"
+    - "${BOOTSTRAP_MESH_DOMAIN}"
   duration: 160h
   privateKey:
     algorithm: ECDSA

--- a/kubernetes/apps/base/mesh-gateway/service.yaml
+++ b/kubernetes/apps/base/mesh-gateway/service.yaml
@@ -1,7 +1,7 @@
 ---
 # Pinned-VIP Service the NetBird resource advertises; *.<MESH_DOMAIN> resolves here.
-# clusterIP MUST equal NETBIRD_GATEWAY_VIP (and the netbird local) and sit in the
-# netbird-gateway ServiceCIDR. targetPort 10443 = Envoy Gateway's +10000 shift of 443.
+# VIP + CIDR are TF-published via bootstrap-settings (single source).
+# targetPort 10443 = Envoy Gateway's +10000 shift of 443.
 # Name must NOT be "envoy" (collides with the controller's own Service).
 apiVersion: v1
 kind: Service
@@ -9,7 +9,7 @@ metadata:
   name: mesh-gateway-vip
 spec:
   type: ClusterIP
-  clusterIP: ${NETBIRD_GATEWAY_VIP}
+  clusterIP: ${BOOTSTRAP_NETBIRD_GATEWAY_VIP}
   selector:
     gateway.envoyproxy.io/owning-gateway-name: mesh
     gateway.envoyproxy.io/owning-gateway-namespace: envoy-system

--- a/kubernetes/apps/base/multus-networks/kustomization.yaml
+++ b/kubernetes/apps/base/multus-networks/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./netbird-egress.yaml

--- a/kubernetes/apps/base/multus-networks/netbird-egress.yaml
+++ b/kubernetes/apps/base/multus-networks/netbird-egress.yaml
@@ -1,0 +1,32 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/k8s.cni.cncf.io/networkattachmentdefinition_v1.json
+# Second interface for mesh-egress pods (external-secrets -> opc). Node-local bridge; the
+# same range on every node is fine — traffic leaves masqueraded as the node peer (the nodes
+# advertise the range). Route scoped to the opc VIP so everything else stays on flannel.
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: netbird-egress
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "netbird-egress",
+      "plugins": [
+        {
+          "type": "bridge",
+          "bridge": "nbegress0",
+          "isGateway": true,
+          "ipMasq": false,
+          "ipam": {
+            "type": "host-local",
+            "ranges": [
+              [{"subnet": "${BOOTSTRAP_NETBIRD_EGRESS_CIDR}", "gateway": "${BOOTSTRAP_NETBIRD_EGRESS_GW}"}]
+            ],
+            "routes": [
+              {"dst": "${CLUSTER_OPC_VIP}/32", "gw": "${BOOTSTRAP_NETBIRD_EGRESS_GW}"}
+            ]
+          }
+        }
+      ]
+    }

--- a/kubernetes/apps/base/multus/helmrelease.yaml
+++ b/kubernetes/apps/base/multus/helmrelease.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/helm.toolkit.fluxcd.io/helmrelease_v2.json
+# Meta-CNI: wraps the Talos flannel config so pods annotated with
+# k8s.v1.cni.cncf.io/networks get extra interfaces; all other pods are untouched.
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: multus
+spec:
+  chartRef:
+    kind: OCIRepository
+    name: multus
+  interval: 1h
+  values:
+    cni:
+      binPath: /opt/cni/bin
+      netPath: /etc/cni/net.d
+    multus:
+      resources:
+        requests:
+          cpu: 10m
+        limits:
+          memory: 512Mi

--- a/kubernetes/apps/base/multus/kustomization.yaml
+++ b/kubernetes/apps/base/multus/kustomization.yaml
@@ -1,0 +1,7 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./ocirepository.yaml
+  - ./helmrelease.yaml

--- a/kubernetes/apps/base/multus/ocirepository.yaml
+++ b/kubernetes/apps/base/multus/ocirepository.yaml
@@ -1,0 +1,13 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: OCIRepository
+metadata:
+  name: multus
+spec:
+  interval: 15m
+  layerSelector:
+    mediaType: application/vnd.cncf.helm.chart.content.v1.tar+gzip
+    operation: copy
+  ref:
+    tag: 1.3.2
+  url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/base/netbird-router/deployment.yaml
+++ b/kubernetes/apps/base/netbird-router/deployment.yaml
@@ -1,6 +1,6 @@
 ---
-# In-cluster NetBird routing peer: enrols via the netbird-setup-key Secret (from
-# kubernetes/helm) and routes peers to the Envoy gateway VIP. 2 replicas for HA.
+# In-cluster NetBird routing peer: routes mesh peers to the Envoy gateway VIP and serves
+# NetBird DNS to the cluster (CoreDNS forwards futo.network to the netbird-dns Service).
 # NET_ADMIN + userspace WireGuard — no tun/privileged.
 apiVersion: apps/v1
 kind: Deployment
@@ -18,6 +18,13 @@ spec:
       labels:
         app.kubernetes.io/name: netbird-router
     spec:
+      # Public upstreams: NetBird forwards non-mesh names to the pod's original resolvers —
+      # with cluster DNS, undistributed futo.network names would loop back through CoreDNS.
+      dnsPolicy: None
+      dnsConfig:
+        nameservers:
+          - 1.1.1.1
+          - 9.9.9.9
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -37,6 +44,16 @@ spec:
                   key: setupKey
             - name: NB_MANAGEMENT_URL
               value: https://api.netbird.io
+            # Bind pod-wide (default is the dynamic NetBird IP) so the Service can front it.
+            - name: NB_DNS_RESOLVER_ADDRESS
+              value: 0.0.0.0:53
+          ports:
+            - name: dns-udp
+              containerPort: 53
+              protocol: UDP
+            - name: dns-tcp
+              containerPort: 53
+              protocol: TCP
           startupProbe:
             exec:
               command: [netbird, status, --check, startup]

--- a/kubernetes/apps/base/netbird-router/kustomization.yaml
+++ b/kubernetes/apps/base/netbird-router/kustomization.yaml
@@ -3,4 +3,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ./deployment.yaml
+  - ./service-dns.yaml
   - ./pdb.yaml

--- a/kubernetes/apps/base/netbird-router/service-dns.yaml
+++ b/kubernetes/apps/base/netbird-router/service-dns.yaml
@@ -1,0 +1,21 @@
+---
+# Stable endpoint for the routers' NetBird DNS resolver; the TF-seeded CoreDNS forwards
+# futo.network here. The IP is TF-published via bootstrap-settings.
+apiVersion: v1
+kind: Service
+metadata:
+  name: netbird-dns
+spec:
+  type: ClusterIP
+  clusterIP: ${BOOTSTRAP_NETBIRD_DNS_IP}
+  selector:
+    app.kubernetes.io/name: netbird-router
+  ports:
+    - name: dns-udp
+      protocol: UDP
+      port: 53
+      targetPort: 53
+    - name: dns-tcp
+      protocol: TCP
+      port: 53
+      targetPort: 53

--- a/kubernetes/apps/base/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs/helmrelease.yaml
@@ -23,9 +23,9 @@ spec:
 
     vlstorage:
       replicaCount: 3
-      retentionPeriod: ${VMLOGS_RETENTION}
+      retentionPeriod: ${CLUSTER_VMLOGS_RETENTION}
       persistentVolume:
-        storageClassName: ${VMLOGS_STORAGE_CLASS}
+        storageClassName: ${CLUSTER_VMLOGS_STORAGE_CLASS}
         size: 100Gi
       topologySpreadConstraints:
         - maxSkew: 1

--- a/kubernetes/apps/base/victoria-metrics-users/vmauth-mesh-unauth.yaml
+++ b/kubernetes/apps/base/victoria-metrics-users/vmauth-mesh-unauth.yaml
@@ -21,7 +21,7 @@ spec:
   selectAllByDefault: false
   httpRoute:
     hostnames:
-      - vmauth.${MESH_DOMAIN}
+      - vmauth.${BOOTSTRAP_MESH_DOMAIN}
     parentRefs:
       - name: mesh
         namespace: envoy-system

--- a/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
@@ -32,7 +32,7 @@ spec:
     vmcluster:
       enabled: true
       spec:
-        retentionPeriod: ${VMETRICS_RETENTION}
+        retentionPeriod: ${CLUSTER_VMETRICS_RETENTION}
         replicationFactor: 2
         vmstorage:
           replicaCount: 3
@@ -141,7 +141,7 @@ spec:
           disabled: true
         httpRoute:
           hostnames:
-            - vmauth.${APP_DOMAIN}
+            - vmauth.${CLUSTER_APP_DOMAIN}
           parentRefs:
             - name: envoy
               namespace: envoy-system

--- a/kubernetes/apps/production/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/production/external-secrets/external-secrets.yaml
@@ -8,6 +8,8 @@ metadata:
 spec:
   dependsOn:
     - name: prometheus-operator-crds
+    # The controller pod's netbird-egress annotation needs the NAD to exist to schedule.
+    - name: multus-networks
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease

--- a/kubernetes/apps/production/kube-system/kustomization.yaml
+++ b/kubernetes/apps/production/kube-system/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ./descheduler.yaml
   - ./metrics-server.yaml
+  - ./multus.yaml
+  - ./multus-networks.yaml
   - ./namespace.yaml
   - ./reloader.yaml
   - ./spegel.yaml

--- a/kubernetes/apps/production/kube-system/multus-networks.yaml
+++ b/kubernetes/apps/production/kube-system/multus-networks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: multus-networks
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: multus
+  interval: 1h
+  path: ./kubernetes/apps/base/multus-networks
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system

--- a/kubernetes/apps/production/kube-system/multus.yaml
+++ b/kubernetes/apps/production/kube-system/multus.yaml
@@ -3,23 +3,23 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: external-secrets
+  name: multus
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: prometheus-operator-crds
-    # The controller pod's netbird-egress annotation needs the NAD to exist to schedule.
-    - name: multus-networks
+  interval: 1h
+  path: ./kubernetes/apps/base/multus
+  prune: true
+  wait: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
-      name: external-secrets
-      namespace: external-secrets
-  interval: 1h
-  path: ./kubernetes/apps/base/external-secrets
-  prune: true
+      name: multus
+      namespace: kube-system
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: network-attachment-definitions.k8s.cni.cncf.io
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: external-secrets
+  targetNamespace: kube-system

--- a/kubernetes/apps/staging/kube-system/kustomization.yaml
+++ b/kubernetes/apps/staging/kube-system/kustomization.yaml
@@ -4,6 +4,8 @@ kind: Kustomization
 resources:
   - ./descheduler.yaml
   - ./metrics-server.yaml
+  - ./multus.yaml
+  - ./multus-networks.yaml
   - ./namespace.yaml
   - ./reloader.yaml
   - ./spegel.yaml

--- a/kubernetes/apps/staging/kube-system/multus-networks.yaml
+++ b/kubernetes/apps/staging/kube-system/multus-networks.yaml
@@ -1,0 +1,19 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: multus-networks
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: multus
+  interval: 1h
+  path: ./kubernetes/apps/base/multus-networks
+  prune: true
+  wait: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  targetNamespace: kube-system

--- a/kubernetes/apps/staging/kube-system/multus.yaml
+++ b/kubernetes/apps/staging/kube-system/multus.yaml
@@ -3,23 +3,23 @@
 apiVersion: kustomize.toolkit.fluxcd.io/v1
 kind: Kustomization
 metadata:
-  name: external-secrets
+  name: multus
   namespace: flux-system
 spec:
-  dependsOn:
-    - name: prometheus-operator-crds
-    # The controller pod's netbird-egress annotation needs the NAD to exist to schedule.
-    - name: multus-networks
+  interval: 1h
+  path: ./kubernetes/apps/base/multus
+  prune: true
+  wait: true
   healthChecks:
     - apiVersion: helm.toolkit.fluxcd.io/v2
       kind: HelmRelease
-      name: external-secrets
-      namespace: external-secrets
-  interval: 1h
-  path: ./kubernetes/apps/base/external-secrets
-  prune: true
+      name: multus
+      namespace: kube-system
+    - apiVersion: apiextensions.k8s.io/v1
+      kind: CustomResourceDefinition
+      name: network-attachment-definitions.k8s.cni.cncf.io
   sourceRef:
     kind: GitRepository
     name: flux-system
     namespace: flux-system
-  targetNamespace: external-secrets
+  targetNamespace: kube-system

--- a/kubernetes/clusters/production/apps.yaml
+++ b/kubernetes/clusters/production/apps.yaml
@@ -26,4 +26,6 @@ spec:
           postBuild:
             substituteFrom:
               - kind: ConfigMap
+                name: bootstrap-settings
+              - kind: ConfigMap
                 name: cluster-settings

--- a/kubernetes/clusters/production/apps.yaml
+++ b/kubernetes/clusters/production/apps.yaml
@@ -25,9 +25,6 @@ spec:
         spec:
           postBuild:
             substituteFrom:
-              # TF-created in-cluster only (bootstrap-settings.tf), so offline renderers
-              # (flate CI) can't see it — optional avoids a hard edge; consumers still
-              # fail loud at apply if it's truly absent.
               - kind: ConfigMap
                 name: bootstrap-settings
                 optional: true

--- a/kubernetes/clusters/production/apps.yaml
+++ b/kubernetes/clusters/production/apps.yaml
@@ -25,7 +25,11 @@ spec:
         spec:
           postBuild:
             substituteFrom:
+              # TF-created in-cluster only (bootstrap-settings.tf), so offline renderers
+              # (flate CI) can't see it — optional avoids a hard edge; consumers still
+              # fail loud at apply if it's truly absent.
               - kind: ConfigMap
                 name: bootstrap-settings
+                optional: true
               - kind: ConfigMap
                 name: cluster-settings

--- a/kubernetes/clusters/production/cluster-settings.yaml
+++ b/kubernetes/clusters/production/cluster-settings.yaml
@@ -5,14 +5,12 @@ metadata:
   name: cluster-settings
   namespace: flux-system
 data:
-  APP_DOMAIN: futostatus.com
-  MESH_DOMAIN: o11y.futo.network
-  # NetBox-allocated; VIP must equal netbird local.netbird_gateway_vip and be in the CIDR.
-  NETBIRD_GATEWAY_VIP: 10.69.0.10
-  NETBIRD_SERVICE_CIDR: 10.69.0.0/24
+  CLUSTER_APP_DOMAIN: futostatus.com
+  # Bootstrap-cluster-owned opc VIP (not o11y TF, hence not in bootstrap-settings).
+  CLUSTER_OPC_VIP: 10.41.19.250
   CLUSTER_NAME: o11y-production
-  OP_O11Y_VAULT: o11y_tf_prod
-  OP_SHARED_VAULT: shared_tf_prod
-  VMLOGS_RETENTION: 120d
-  VMLOGS_STORAGE_CLASS: openebs-spare-disk-2
-  VMETRICS_RETENTION: 120d
+  CLUSTER_OP_O11Y_VAULT: o11y_tf_prod
+  CLUSTER_OP_SHARED_VAULT: shared_tf_prod
+  CLUSTER_VMLOGS_RETENTION: 120d
+  CLUSTER_VMLOGS_STORAGE_CLASS: openebs-spare-disk-2
+  CLUSTER_VMETRICS_RETENTION: 120d

--- a/kubernetes/clusters/staging/apps.yaml
+++ b/kubernetes/clusters/staging/apps.yaml
@@ -26,4 +26,6 @@ spec:
           postBuild:
             substituteFrom:
               - kind: ConfigMap
+                name: bootstrap-settings
+              - kind: ConfigMap
                 name: cluster-settings

--- a/kubernetes/clusters/staging/apps.yaml
+++ b/kubernetes/clusters/staging/apps.yaml
@@ -25,9 +25,6 @@ spec:
         spec:
           postBuild:
             substituteFrom:
-              # TF-created in-cluster only (bootstrap-settings.tf), so offline renderers
-              # (flate CI) can't see it — optional avoids a hard edge; consumers still
-              # fail loud at apply if it's truly absent.
               - kind: ConfigMap
                 name: bootstrap-settings
                 optional: true

--- a/kubernetes/clusters/staging/apps.yaml
+++ b/kubernetes/clusters/staging/apps.yaml
@@ -25,7 +25,11 @@ spec:
         spec:
           postBuild:
             substituteFrom:
+              # TF-created in-cluster only (bootstrap-settings.tf), so offline renderers
+              # (flate CI) can't see it — optional avoids a hard edge; consumers still
+              # fail loud at apply if it's truly absent.
               - kind: ConfigMap
                 name: bootstrap-settings
+                optional: true
               - kind: ConfigMap
                 name: cluster-settings

--- a/kubernetes/clusters/staging/cluster-settings.yaml
+++ b/kubernetes/clusters/staging/cluster-settings.yaml
@@ -5,14 +5,12 @@ metadata:
   name: cluster-settings
   namespace: flux-system
 data:
-  APP_DOMAIN: staging.futostatus.com
-  MESH_DOMAIN: staging.o11y.futo.network
-  # NetBox-allocated; VIP must equal netbird local.netbird_gateway_vip and be in the CIDR.
-  NETBIRD_GATEWAY_VIP: 10.69.1.10
-  NETBIRD_SERVICE_CIDR: 10.69.1.0/24
+  CLUSTER_APP_DOMAIN: staging.futostatus.com
+  # Bootstrap-cluster-owned opc VIP (not o11y TF, hence not in bootstrap-settings).
+  CLUSTER_OPC_VIP: 10.41.19.250
   CLUSTER_NAME: o11y-staging
-  OP_O11Y_VAULT: o11y_tf_staging
-  OP_SHARED_VAULT: shared_tf_staging
-  VMLOGS_RETENTION: 30d
-  VMLOGS_STORAGE_CLASS: openebs-spare-disk
-  VMETRICS_RETENTION: 30d
+  CLUSTER_OP_O11Y_VAULT: o11y_tf_staging
+  CLUSTER_OP_SHARED_VAULT: shared_tf_staging
+  CLUSTER_VMLOGS_RETENTION: 30d
+  CLUSTER_VMLOGS_STORAGE_CLASS: openebs-spare-disk
+  CLUSTER_VMETRICS_RETENTION: 30d


### PR DESCRIPTION
Lets the external-secrets controller reach the bootstrap cluster's 1Password Connect (`opc.o11y.futo.network`) over the NetBird mesh, and gives every pod DNS for `futo.network` names.

- **multus** (bjw-s chart, mirrors onedr0p/home-ops) + a `netbird-egress` NAD: the ESO controller gets a second interface in a node-advertised range, so NetBird's own masquerade rules carry opc traffic out `wt0`. Mechanism verified end-to-end on staging (HTTP 200, valid TLS).
- **CoreDNS is TF-seeded** (`kubernetes/helm`, Talos copy disabled) — Flux needs DNS before it can install anything. The chart adopts the Talos objects in place (`take_ownership` + pinned selectors, zero-gap) and forwards `futo.network` to the netbird-router resolver via the pinned `netbird-dns` Service.
- **bootstrap-settings** ConfigMap publishes TF-owned values to Flux substitution (`BOOTSTRAP_*`); cluster-settings keys renamed `CLUSTER_*`.
- Pins worker kubelet `nodeIP` to the vRack (a stray `10.x` address stole a worker's InternalIP during testing) and `clusterDNS` explicitly.

All TF is already applied to both envs; merging only drives the Flux side. The ClusterSecretStores still point at the local Connect — the cutover to the remote Connect follows separately once the bootstrap-issued token exists.