### PR TITLE
feat: point ExternalSecrets at bootstrap-hosted 1Password Connect

### DIFF
--- a/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
+++ b/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
@@ -1,23 +1,9 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/clustersecretstore_v1.json
-apiVersion: external-secrets.io/v1
-kind: ClusterSecretStore
-metadata:
-  name: onepassword
-spec:
-  provider:
-    onepassword:
-      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
-      vaults:
-        o11y_tf: 1
-      auth:
-        secretRef:
-          connectTokenSecretRef:
-            name: onepassword-connect
-            namespace: external-secrets
-            key: token
----
-# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/clustersecretstore_v1.json
+# Auth to the o11y 1Password Connect, now hosted in bootstrap (opc.o11y.futo.network) over
+# the mesh. Same Connect server entity as the retired in-cluster one, so the existing
+# onepassword-connect-environment token carries over unchanged. The superuser store is
+# dropped here; no ExternalSecret referenced it.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:
@@ -25,7 +11,7 @@ metadata:
 spec:
   provider:
     onepassword:
-      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+      connectHost: https://opc.o11y.futo.network
       vaults:
         ${CLUSTER_OP_O11Y_VAULT}: 1
       auth:
@@ -43,7 +29,7 @@ metadata:
 spec:
   provider:
     onepassword:
-      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+      connectHost: https://opc.o11y.futo.network
       vaults:
         shared_tf: 1
       auth:
@@ -61,7 +47,7 @@ metadata:
 spec:
   provider:
     onepassword:
-      connectHost: http://onepassword-connect.external-secrets.svc.cluster.local:8080
+      connectHost: https://opc.o11y.futo.network
       vaults:
         ${CLUSTER_OP_SHARED_VAULT}: 1
       auth:

--- a/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
+++ b/kubernetes/apps/base/cluster-secret-store/clustersecretstore.yaml
@@ -1,9 +1,5 @@
 ---
 # yaml-language-server: $schema=https://k8s-schemas.home-operations.com/external-secrets.io/clustersecretstore_v1.json
-# Auth to the o11y 1Password Connect, now hosted in bootstrap (opc.o11y.futo.network) over
-# the mesh. Same Connect server entity as the retired in-cluster one, so the existing
-# onepassword-connect-environment token carries over unchanged. The superuser store is
-# dropped here; no ExternalSecret referenced it.
 apiVersion: external-secrets.io/v1
 kind: ClusterSecretStore
 metadata:


### PR DESCRIPTION
Phase 2 of retiring o11y's in-cluster 1Password Connect: repoint the ExternalSecrets stores at the o11y Connect now hosted in the bootstrap cluster, reached over the NetBird mesh.

The three `ClusterSecretStore`s flip `connectHost` from the in-cluster Service to `https://opc.o11y.futo.network`. Bootstrap runs the **same** 1Password Connect server entity (it reuses o11y's `credentials.json`), so the existing `onepassword-connect-environment` token authenticates unchanged - no new token, no `.env` change, no TF reseed. The cutover is a pure Flux reconcile.

Also drops the `onepassword` superuser store: no ExternalSecret referenced it (0 of 7).

Verified on staging before opening: o11y's existing token → `https://opc.o11y.futo.network/v1/vaults` returns HTTP 200 with its vaults visible, over the egress NAD path. Existing k8s Secrets persist through the flip, so a bad cutover is a soft failure (delayed refresh), not an outage.

Not in this PR:
- The in-cluster Connect deployment + its credentials/superuser TF plumbing stay (Phase 3 cleanup, keeps this reversible via `git revert`).
- o11y's `netbird/cluster` looks up NetBird group `bootstrap-resources`; bootstrap renamed it `bootstrap-gateway`. Resolves today; coordinate before the next `netbird/cluster` apply.