### PR TITLE
feat: HA kube-apiserver access over the mesh (TLS passthrough)

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -74,10 +74,14 @@ run = """
 : "${ENVIRONMENT:?set ENVIRONMENT=staging (or production) first}"
 mkdir -p {{config_root}}/.private/${ENVIRONMENT}
 mise run tg run --working-dir deployment/modules/talos/cluster output -- -raw kubeconfig > {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
-sd 'server: https://10[.]150[.]([0-9]+)[.]5:6443' 'server: https://10.150.${1}.10:6443' {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
+# HA endpoint fronted by the mesh gateway (Envoy TLS-passthrough -> apiservers), so kubectl
+# is no longer pinned to one CP. Break-glass for bootstrap/DR before the gateway is up:
+# kubectl --server=https://<cp-private-ip>:6443 (each CP private IP is an apiserver cert SAN).
+if [ "${ENVIRONMENT}" = "production" ]; then MESH_HOST="kube.o11y.futo.network"; else MESH_HOST="kube.${ENVIRONMENT}.o11y.futo.network"; fi
+sd 'server: https://10[.]150[.][0-9]+[.]5:6443' "server: https://${MESH_HOST}:6443" {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
 chmod 600 {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
 """
-description = "Fetch kubeconfig for $ENVIRONMENT into .private/<env>/ (server repointed to a CP private IP)"
+description = "Fetch kubeconfig for $ENVIRONMENT into .private/<env>/ (server = HA mesh endpoint kube.<zone>)"
 dir = "{{cwd}}"
 
 [tasks.tg]

--- a/deployment/modules/netbird/cluster/netbird.tf
+++ b/deployment/modules/netbird/cluster/netbird.tf
@@ -151,7 +151,8 @@ resource "netbird_dns_record" "mesh_wildcard" {
   ttl     = 300
 }
 
-# Allow yucca peers to reach the gateway VIP over HTTPS.
+# Allow yucca peers to reach the gateway VIP: 443 for workloads, 6443 for the HA
+# kube-apiserver endpoint (Envoy TLS-passthrough; see mesh-gateway-api).
 resource "netbird_policy" "yucca_to_k8s_gateway" {
   name    = "O11Y_${upper(var.env)}_YUCCA_TO_K8S_GATEWAY"
   enabled = true
@@ -164,7 +165,7 @@ resource "netbird_policy" "yucca_to_k8s_gateway" {
     bidirectional = false
     sources       = [data.netbird_group.yucca.id]
     destinations  = [netbird_group.k8s_gateway.id]
-    ports         = ["443"]
+    ports         = ["443", "6443"]
   }
 }
 

--- a/deployment/modules/talos/cluster/controlplane.tf
+++ b/deployment/modules/talos/cluster/controlplane.tf
@@ -120,11 +120,13 @@ resource "talos_machine_configuration_apply" "controlplane" {
           }
         }
         apiServer = {
-          # VIP for in-cluster traffic; CP private IPs for operators reaching the
-          # apiserver over the mesh (the floating VIP doesn't ARP reliably across DCs).
+          # VIP for in-cluster traffic; CP private IPs for direct/break-glass operator
+          # access; kube.<mesh-zone> for the HA endpoint the mesh gateway fronts (Envoy
+          # TLS-passthrough -> apiservers). The floating VIP doesn't ARP across DCs.
           certSANs = concat(
             [local.controlplane_vip],
             [for k in local.controlplane_keys : var.controlplane_nodes[k].private_ip],
+            ["kube.${var.mesh_dns_zone}"],
           )
         }
       }

--- a/deployment/modules/talos/cluster/terragrunt.hcl
+++ b/deployment/modules/talos/cluster/terragrunt.hcl
@@ -67,6 +67,7 @@ dependency "netbird_cluster" {
   config_path = "../../netbird/cluster"
   mock_outputs = {
     talos_setup_key = "mock-netbird-setup-key"
+    mesh_dns_zone   = "mock.o11y.futo.network"
   }
   mock_outputs_allowed_terraform_commands = ["init", "validate", "plan"]
 }
@@ -80,6 +81,7 @@ inputs = {
   worker_data_disk2_match = local.worker_data_disk2_match
   worker_nics             = local.worker_nics
   netbird_setup_key       = dependency.netbird_cluster.outputs.talos_setup_key
+  mesh_dns_zone           = dependency.netbird_cluster.outputs.mesh_dns_zone
 }
 
 generate "backend" {

--- a/deployment/modules/talos/cluster/variables.tf
+++ b/deployment/modules/talos/cluster/variables.tf
@@ -92,3 +92,9 @@ variable "use_public_endpoints" {
   type    = bool
   default = false
 }
+
+# Mesh DNS zone (from netbird/cluster) — used for the kube.<zone> apiserver certSAN so
+# kubectl can reach the HA endpoint the mesh gateway fronts (Envoy TLS-passthrough).
+variable "mesh_dns_zone" {
+  type = string
+}

--- a/kubernetes/apps/base/mesh-gateway-api/kustomization.yaml
+++ b/kubernetes/apps/base/mesh-gateway-api/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./tlsroute.yaml

--- a/kubernetes/apps/base/mesh-gateway-api/tlsroute.yaml
+++ b/kubernetes/apps/base/mesh-gateway-api/tlsroute.yaml
@@ -1,0 +1,21 @@
+---
+# HA kube-apiserver over the mesh: SNI kube.<MESH_DOMAIN> -> the default/kubernetes Service
+# (auto-managed endpoints = the apiservers), TLS passed through so kubectl validates the
+# apiserver's own cert. Lives in default (same ns as the backend) so no ReferenceGrant is
+# needed; attaches cross-ns to the mesh Gateway, which allows routes from all namespaces.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: kube-apiserver
+  namespace: default
+spec:
+  parentRefs:
+    - name: mesh
+      namespace: envoy-system
+      sectionName: kube-api
+  hostnames:
+    - kube.${BOOTSTRAP_MESH_DOMAIN}
+  rules:
+    - backendRefs:
+        - name: kubernetes
+          port: 443

--- a/kubernetes/apps/base/mesh-gateway/gateway.yaml
+++ b/kubernetes/apps/base/mesh-gateway/gateway.yaml
@@ -19,3 +19,15 @@ spec:
         certificateRefs:
           - kind: Secret
             name: o11y-futo-network-tls
+    # HA kube-apiserver endpoint (kube.<MESH_DOMAIN>). TLS passthrough: Envoy routes by SNI
+    # to the apiservers, which present their own cert end-to-end (see mesh-gateway-api).
+    - name: kube-api
+      protocol: TLS
+      port: 6443
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        kinds:
+          - kind: TLSRoute
+        namespaces:
+          from: All

--- a/kubernetes/apps/base/mesh-gateway/service.yaml
+++ b/kubernetes/apps/base/mesh-gateway/service.yaml
@@ -18,3 +18,8 @@ spec:
       protocol: TCP
       port: 443
       targetPort: 10443
+    # kube-api: 6443 >= 1024 so Envoy binds it directly (no +10000 privileged-port shift).
+    - name: kube-api
+      protocol: TCP
+      port: 6443
+      targetPort: 6443

--- a/kubernetes/apps/production/envoy-system/kustomization.yaml
+++ b/kubernetes/apps/production/envoy-system/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./envoy-proxy.yaml
   - ./mesh-gateway-network.yaml
   - ./mesh-gateway.yaml
+  - ./mesh-gateway-api.yaml
   - ./namespace.yaml

--- a/kubernetes/apps/production/envoy-system/mesh-gateway-api.yaml
+++ b/kubernetes/apps/production/envoy-system/mesh-gateway-api.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mesh-gateway-api
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: mesh-gateway
+  interval: 1h
+  path: ./kubernetes/apps/base/mesh-gateway-api
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true

--- a/kubernetes/apps/staging/envoy-system/kustomization.yaml
+++ b/kubernetes/apps/staging/envoy-system/kustomization.yaml
@@ -7,4 +7,5 @@ resources:
   - ./envoy-proxy.yaml
   - ./mesh-gateway-network.yaml
   - ./mesh-gateway.yaml
+  - ./mesh-gateway-api.yaml
   - ./namespace.yaml

--- a/kubernetes/apps/staging/envoy-system/mesh-gateway-api.yaml
+++ b/kubernetes/apps/staging/envoy-system/mesh-gateway-api.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: mesh-gateway-api
+  namespace: flux-system
+spec:
+  dependsOn:
+    - name: mesh-gateway
+  interval: 1h
+  path: ./kubernetes/apps/base/mesh-gateway-api
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: true


### PR DESCRIPTION
Closes #34.

Operator access to the kube API is currently pinned to a single control-plane IP over NetBird (the Talos VIP can't ARP across our OVH DCs). That's not HA (a down CP breaks kubectl) and it causes the recurring "elected routing peer == the CP you're pinned to" hairpin.

This fronts the apiserver with the **existing Envoy mesh gateway** instead:

- **mesh-gateway**: a `kube-api` TLS-**passthrough** listener on `:6443` + a `:6443` port on the pinned VIP Service (6443 ≥ 1024, so Envoy binds it directly - no +10000 shift).
- **mesh-gateway-api** (new): a `TLSRoute` matching SNI `kube.<mesh-zone>` → the `default/kubernetes` Service. It lives in `default` (same ns as the backend, so no ReferenceGrant) and attaches cross-namespace to the gateway.
- **talos**: `kube.<mesh-zone>` added to the apiserver `certSANs` (`mesh_dns_zone` sourced from the netbird dependency).
- **netbird**: `:6443` added to the `yucca → k8s_gateway` policy.
- **mise `talos:kubeconfig`**: server → the mesh endpoint, with `kubectl --server=https://<cp>:6443` documented as the break-glass.

Path: `kubectl → kube.<zone>:6443` → (mesh wildcard DNS) gateway VIP → the **netbird-router pods** (routing peers, not CPs) → Envoy SNI-passthrough → `kubernetes` svc → a healthy apiserver. HA via kube-proxy/Envoy across all apiservers; the hairpin is gone because no CP is in the path.

### Bootstrap / DR (chicken-and-egg)
The mesh endpoint is purely additive for steady-state. Cluster-create and DR stay on a direct CP: TF's `operator_endpoint` is unchanged, and the `certSAN` is present from first boot (long before Envoy exists), so there's no ordering trap. Break-glass is `kubectl --server=https://<cp-private-ip>:6443` (each CP IP is a cert SAN).

### Verified on staging (throwaway listener+route, since reverted)
- TLSRoute `Accepted`, listener `Programmed`, `attachedRoutes=1`
- The **served cert is the apiserver's own** (`issuer=O=kubernetes`, `CN=kube-apiserver`, SANs = the 3 CP IPs + VIP), not Envoy's wildcard → genuine passthrough
- `/version` answered by the apiserver; `kubernetes` svc fronts all 3 CPs (HA)
- workload ingress (`vmauth`) stayed `200` while the listener was attached

### Rollout (after merge)
1. TF `talos/cluster` per env (`tf:init` first): adds the certSAN → Talos reissues the apiserver cert and rolling-restarts kube-apiserver (one CP at a time).
2. TF `netbird/cluster` per env: opens `:6443` to the gateway VIP.
3. Merge lands the listener + TLSRoute; then regenerate kubeconfig.

Supersedes the workers-only-routing idea (not needed - the hairpin is designed out).