### PR TITLE
refactor: derive the kubeconfig mesh endpoint in terraform

### DIFF
--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -73,12 +73,10 @@ dir = "{{cwd}}"
 run = """
 : "${ENVIRONMENT:?set ENVIRONMENT=staging (or production) first}"
 mkdir -p {{config_root}}/.private/${ENVIRONMENT}
-mise run tg run --working-dir deployment/modules/talos/cluster output -- -raw kubeconfig > {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
-# HA endpoint fronted by the mesh gateway (Envoy TLS-passthrough -> apiservers), so kubectl
-# is no longer pinned to one CP. Break-glass for bootstrap/DR before the gateway is up:
+# The kubeconfig output already points at the HA mesh endpoint (kube.<zone>, rewritten in
+# talos/cluster outputs.tf). Break-glass for bootstrap/DR before the gateway is up:
 # kubectl --server=https://<cp-private-ip>:6443 (each CP private IP is an apiserver cert SAN).
-if [ "${ENVIRONMENT}" = "production" ]; then MESH_HOST="kube.o11y.futo.network"; else MESH_HOST="kube.${ENVIRONMENT}.o11y.futo.network"; fi
-sd 'server: https://10[.]150[.][0-9]+[.]5:6443' "server: https://${MESH_HOST}:6443" {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
+mise run tg run --working-dir deployment/modules/talos/cluster output -- -raw kubeconfig > {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
 chmod 600 {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
 """
 description = "Fetch kubeconfig for $ENVIRONMENT into .private/<env>/ (server = HA mesh endpoint kube.<zone>)"

--- a/deployment/modules/talos/cluster/outputs.tf
+++ b/deployment/modules/talos/cluster/outputs.tf
@@ -16,7 +16,14 @@ output "talos_client_configuration" {
   value     = data.talos_client_configuration.this.talos_config
 }
 
+# Server rewritten from the (in-cluster-only) VIP to the HA mesh endpoint, so the zone
+# special-case lives only in netbird/cluster's mesh_dns_zone. Break-glass for bootstrap/DR
+# before the gateway exists: kubectl --server=https://<cp-private-ip>:6443 (all cert SANs).
 output "kubeconfig" {
   sensitive = true
-  value     = talos_cluster_kubeconfig.this.kubeconfig_raw
+  value = replace(
+    talos_cluster_kubeconfig.this.kubeconfig_raw,
+    "server: ${local.cluster_endpoint}",
+    "server: https://kube.${var.mesh_dns_zone}:6443",
+  )
 }


### PR DESCRIPTION
The `mise talos:kubeconfig` task duplicated logic TF already owns: an `if production` zone derivation plus an `sd` regex rewrite of the server line. The `kubeconfig` output now does the rewrite itself - `replace()` swaps `server: <VIP>` for `server: https://kube.${var.mesh_dns_zone}:6443`, using the zone `talos/cluster` already receives from the netbird dependency (#101). Prod's special-case now lives in exactly one place (`netbird/cluster`'s `mesh_dns_zone`), and the mise task collapses to fetch + chmod.

Output-only change - no resources touched, nothing to apply. If the replace anchor ever misses, the output keeps the VIP endpoint, which fails loudly on first use rather than pointing somewhere wrong. Break-glass (`--server=https://<cp-ip>:6443`) unchanged and documented at both sites.