### PR TITLE
refactor: futo-org netbird provider + rfc1123 object names

### DIFF
--- a/deployment/modules/netbird/cluster/.terraform.lock.hcl
+++ b/deployment/modules/netbird/cluster/.terraform.lock.hcl
@@ -2,8 +2,7 @@
 # Manual edits may be lost in future updates.
 
 provider "registry.opentofu.org/netbirdio/netbird" {
-  version     = "0.0.9"
-  constraints = "0.0.9"
+  version = "0.0.9"
   hashes = [
     "h1:0Vi0MLMk+K1CEuBZB+ByU55wXx87eGd5j0fGACekCDQ=",
     "h1:2ska0C0jDxvbjApKlUmdkfrXQFjHiNf/KKYt355Isgo=",
@@ -34,5 +33,29 @@ provider "registry.opentofu.org/netbirdio/netbird" {
     "zh:bcdeef5fadf092e33228f28f013af7d8d9553b9d2fb2cecd1894351d5ad37a7a",
     "zh:d6c31cb12f18b25c9663c14e737554e06144d4e270e607337bac7963ca3b9542",
     "zh:e5873e8e0b29c8cbfd98f04759579da3c0529c8b38608c0f1ea92eb566c8ddc1",
+  ]
+}
+
+provider "registry.terraform.io/futo-org/netbird" {
+  version     = "1.0.2"
+  constraints = "1.0.2"
+  hashes = [
+    "h1:++sZUO9jm4pezIuPdEKS4Fr/FeDCRGI55ZvL0fqRkCg=",
+    "h1:CE91Uvc3FhpgpwgjVR96ueerThTZSCTcKF8Rp2+lzQw=",
+    "h1:Oo+Ck3+1EwXBiYM3S2YFpOiwllXw58zzLLFa2Ps+XVE=",
+    "zh:1a1b727dd3971eb0f4c923c19fa95100e5b91b163ae0607f72a37d656f9d71a6",
+    "zh:5169993e54c6b184cdb359fb310477d85eeb99d1d91db14d367a29bf3119dc55",
+    "zh:573279b9532f916ee4bfb4e12faacf26e8e27df626ac37e1a5c42d5eab2350a4",
+    "zh:5cafd8cb073fc6774d959080c06b6faf821c3a7caaf3d876a40be8b8945a70fd",
+    "zh:66d40bbde6d756160a94e8c908582cb7806acccbebe0e9060b82cb4993f5adad",
+    "zh:6eb6493922345ec4306d8f0e95e799a6045ff3b25fd05973828e960757df5b97",
+    "zh:88c638c29d7dad339f1c4e90e54d0996be85a95574d5d9c5f125cb0bbb5b8902",
+    "zh:890df766e9b839623b1f0437355032a3c006226a6c200cd911e15ee1a9014e9f",
+    "zh:89cca24eeb5305cfcac51092bd0c330336af6613648f14a4c70f23a56fe4e93d",
+    "zh:91186b07d2ee1494bcd7e2c132ca1c61b62b2a1f2d325d2bbc4bfe6572ce327d",
+    "zh:aa6cbe8f5c8121d96861e293d3773cc210723fa410acf45512a337703d55d911",
+    "zh:d38dce0bcc61ca2482ee3b9f457ebf45929c7ebc8717487d9f1270aa3dcd3cfa",
+    "zh:dba9742f0a0cb5e190a10265ec00d20a4d266f8a6dd517cb4c1d8486335ed636",
+    "zh:e8eaabc072208c10ab554b4c89dbe32831a7d0125ab628af4a6530a02ea5a993",
   ]
 }

--- a/deployment/modules/netbird/cluster/config.tf
+++ b/deployment/modules/netbird/cluster/config.tf
@@ -2,9 +2,12 @@ terraform {
   required_version = "~> 1.10"
 
   required_providers {
+    # FUTO-maintained fork (github.com/futo-org/terraform-provider-netbird), like yucca.
+    # Only published to the Terraform registry, so the source is fully qualified —
+    # OpenTofu would otherwise look it up on registry.opentofu.org.
     netbird = {
-      source  = "netbirdio/netbird"
-      version = "0.0.9"
+      source  = "registry.terraform.io/futo-org/netbird"
+      version = "1.0.2" # fixes group TF->API resources decode (rename of groups with tagged resources)
     }
   }
 }

--- a/deployment/modules/netbird/cluster/netbird.tf
+++ b/deployment/modules/netbird/cluster/netbird.tf
@@ -2,8 +2,9 @@
 # per-env — resource groups and policies included — so access can differ by env
 # (Zack: some people get dev/staging but not prod). No account-wide layer.
 #
-# All object names are UPPER_SNAKE to match yucca's convention (groups, setup keys,
-# networks, network resources, and policies/rules).
+# Object names are rfc1123 (lowercase-hyphen). Exception: the setup keys keep their
+# original UPPER_SNAKE names — renaming a key is RequiresReplace (new key value), which
+# cascades into talos machine configs + the router Secret; rename at the next rotation.
 
 # Existing account-wide users group (yucca peers — populated via users' auto_groups,
 # per NetBird's model). Referenced as the policy source so the same operators that
@@ -14,14 +15,13 @@ data "netbird_group" "yucca" {
 
 # Group the Talos nodes auto-join via the setup key below.
 resource "netbird_group" "talos" {
-  name = "O11Y_${upper(var.env)}_TALOS"
+  name = "o11y-${var.env}-talos"
 }
 
 # Per-env tag for this cluster's routed resources (the vRack subnet below tags into
-# it; the yucca->resource policy grants it). Created with its final name — the
-# NetBird provider can't rename a group once network resources are tagged into it.
+# it; the yucca->resource policy grants it).
 resource "netbird_group" "o11y_resource" {
-  name = "O11Y_${upper(var.env)}_RESOURCE"
+  name = "o11y-${var.env}-resource"
 }
 
 # Reusable, non-ephemeral enrollment key for the Talos nodes — fed to the netbird
@@ -41,7 +41,7 @@ resource "netbird_setup_key" "talos" {
 # masquerade NATs operator traffic to the routing peer's vRack IP, which the node
 # firewall already trusts.
 resource "netbird_network" "vrack" {
-  name        = "O11Y_${upper(var.env)}_VRACK"
+  name        = "o11y-${var.env}-vrack"
   description = "o11y ${var.env} vRack private subnet"
 }
 
@@ -56,7 +56,7 @@ resource "netbird_network_router" "vrack" {
 resource "netbird_network_resource" "vrack" {
   network_id = netbird_network.vrack.id
   # Per-env: Netbird network-resource names are account-globally unique.
-  name    = "O11Y_${upper(var.env)}_VRACK_CIDR"
+  name    = "o11y-${var.env}-vrack-cidr"
   address = var.private_network_cidr
   groups  = [netbird_group.o11y_resource.id]
   enabled = true
@@ -65,11 +65,11 @@ resource "netbird_network_resource" "vrack" {
 # NetBird default-denies; allow yucca to reach this env's routed subnet on the Talos
 # management ports (apid + kube-apiserver).
 resource "netbird_policy" "yucca_to_o11y_resource" {
-  name    = "O11Y_${upper(var.env)}_YUCCA_TO_RESOURCE"
+  name    = "o11y-${var.env}-yucca-to-resource"
   enabled = true
 
   rule {
-    name          = "YUCCA_TO_O11Y_RESOURCE"
+    name          = "yucca-to-o11y-resource"
     action        = "accept"
     protocol      = "tcp"
     enabled       = true
@@ -92,15 +92,15 @@ locals {
 }
 
 resource "netbird_group" "k8s_routing_peers" {
-  name = "O11Y_${upper(var.env)}_K8S_ROUTING_PEERS"
+  name = "o11y-${var.env}-k8s-routing-peers"
 }
 
 resource "netbird_group" "k8s_gateway" {
-  name = "O11Y_${upper(var.env)}_K8S_GATEWAY"
+  name = "o11y-${var.env}-k8s-gateway"
 }
 
 resource "netbird_network" "k8s" {
-  name        = "O11Y_${upper(var.env)}_K8S"
+  name        = "o11y-${var.env}-k8s"
   description = "o11y ${var.env} in-cluster workload ingress (Envoy gateway)"
 }
 
@@ -115,7 +115,7 @@ resource "netbird_network_router" "k8s" {
 # The Envoy gateway VIP as a /32 (mesh-gateway/service.yaml) — peers reach only this IP.
 resource "netbird_network_resource" "k8s_gateway" {
   network_id = netbird_network.k8s.id
-  name       = "O11Y_${upper(var.env)}_K8S_GATEWAY"
+  name       = "o11y-${var.env}-k8s-gateway"
   address    = "${local.netbird_gateway_vip}/32"
   groups     = [netbird_group.k8s_gateway.id]
   enabled    = true
@@ -154,11 +154,11 @@ resource "netbird_dns_record" "mesh_wildcard" {
 # Allow yucca peers to reach the gateway VIP: 443 for workloads, 6443 for the HA
 # kube-apiserver endpoint (Envoy TLS-passthrough; see mesh-gateway-api).
 resource "netbird_policy" "yucca_to_k8s_gateway" {
-  name    = "O11Y_${upper(var.env)}_YUCCA_TO_K8S_GATEWAY"
+  name    = "o11y-${var.env}-yucca-to-k8s-gateway"
   enabled = true
 
   rule {
-    name          = "YUCCA_TO_K8S_GATEWAY"
+    name          = "yucca-to-k8s-gateway"
     action        = "accept"
     protocol      = "tcp"
     enabled       = true
@@ -178,7 +178,7 @@ locals {
 }
 
 resource "netbird_network" "k8s_egress" {
-  name        = "O11Y_${upper(var.env)}_K8S_EGRESS"
+  name        = "o11y-${var.env}-k8s-egress"
   description = "o11y ${var.env} pod egress range (Multus netbird-egress NAD)"
 }
 
@@ -194,7 +194,7 @@ resource "netbird_network_router" "k8s_egress" {
 # (a policy-less group left every node unprogrammed). The yucca 50000/6443 grant is inert here.
 resource "netbird_network_resource" "k8s_egress" {
   network_id = netbird_network.k8s_egress.id
-  name       = "O11Y_${upper(var.env)}_K8S_EGRESS_CIDR"
+  name       = "o11y-${var.env}-k8s-egress-cidr"
   address    = local.netbird_egress_cidr
   groups     = [netbird_group.o11y_resource.id]
   enabled    = true
@@ -207,11 +207,11 @@ data "netbird_group" "bootstrap_opc" {
 
 # Egress leaves masqueraded as the node peer -> nodes are the source; also pushes them the opc /32 route.
 resource "netbird_policy" "talos_to_bootstrap_opc" {
-  name    = "O11Y_${upper(var.env)}_TALOS_TO_BOOTSTRAP_OPC"
+  name    = "o11y-${var.env}-talos-to-bootstrap-opc"
   enabled = true
 
   rule {
-    name          = "TALOS_TO_BOOTSTRAP_OPC"
+    name          = "talos-to-bootstrap-opc"
     action        = "accept"
     protocol      = "tcp"
     enabled       = true


### PR DESCRIPTION
Two commits, both already applied and verified on staging + production.

**Provider switch** - `netbirdio/netbird 0.0.9` → `registry.terraform.io/futo-org/netbird 1.0.2` (the FUTO fork yucca already pins). Its group resources round-trip fix is what makes the rename below possible: 0.0.9 errored on renaming any group with network resources tagged. One-time state migration per env: `state replace-provider`, plus `state rm` + `import` of the two resource-tagged groups - the fork changed the group `resources` schema to `{id,type}` objects without a `StateUpgrader` for old state (issue to be filed upstream).

**Rename** - all groups, networks, network resources, and policies/rules go `O11Y_<ENV>_*` → `o11y-<env>-*` per the rfc1123 naming convention. Every change was an in-place label update (`13 to change, 0 add/destroy` per env); IDs are untouched, so nothing reprogrammed. Verified after each env: kubectl (mesh + direct contexts), vmauth ingress, ESO 7/7 synced, opc egress 200.

Deliberately out of scope: the two setup keys keep their UPPER_SNAKE names - key rename is `RequiresReplace` (new key value) and cascades into talos machine configs + the router Secret, so it waits for the next natural key rotation. The `bootstrap-resources` data-source lookup is also unchanged (still the live group name; coordinating its rename with the bootstrap side separately).