### PR TITLE
fix: carry OCI chart digests in the production patches

### DIFF
--- a/kubernetes/apps/base/cert-manager/ocirepository.yaml
+++ b/kubernetes/apps/base/cert-manager/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: v1.19.4
+    digest: sha256:135b97727e98ab0af229c2dceaf2e2c3c074a7b83495c6e09a1697c85e5ef6c7
   url: oci://quay.io/jetstack/charts/cert-manager

--- a/kubernetes/apps/base/cloudnative-pg/ocirepository.yaml
+++ b/kubernetes/apps/base/cloudnative-pg/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.28.2
+    digest: sha256:395480811b5472e8e3c3f1d98d838596019d50b109e26bb0eb537c227fba679a
   url: oci://ghcr.io/cloudnative-pg/charts/cloudnative-pg

--- a/kubernetes/apps/base/descheduler/ocirepository.yaml
+++ b/kubernetes/apps/base/descheduler/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.36.0
+    digest: sha256:b1f1d872bf64ebf88437467f4a2217bd08cf0e3cd07861e281f20b7b578d5c18
   url: oci://ghcr.io/home-operations/charts-mirror/descheduler

--- a/kubernetes/apps/base/envoy-gateway/ocirepository.yaml
+++ b/kubernetes/apps/base/envoy-gateway/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 1.7.0
+    digest: sha256:fdc01017304bc676fb7097d1fe8ceda5cc1c9673bf1c01a7576898623b3310f7
   url: oci://mirror.gcr.io/envoyproxy/gateway-helm

--- a/kubernetes/apps/base/external-secrets/ocirepository.yaml
+++ b/kubernetes/apps/base/external-secrets/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 2.2.0
+    digest: sha256:feb252e996e2ce31ea015a1e098f2c5d438389a0a2fc1f43659b3f5421046f6f
   url: oci://ghcr.io/external-secrets/charts/external-secrets

--- a/kubernetes/apps/base/grafana-operator/ocirepository.yaml
+++ b/kubernetes/apps/base/grafana-operator/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 5.24.0
+    digest: sha256:4f69cdaecfed2cc61d4e5f4a8e7142795e9b00997e4bcbd37a8c154a225a2f1f
   url: oci://ghcr.io/grafana/helm-charts/grafana-operator

--- a/kubernetes/apps/base/metrics-server/ocirepository.yaml
+++ b/kubernetes/apps/base/metrics-server/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 3.13.0
+    digest: sha256:40f86072c24a94faa1ae0035fa4688364f97cd7d9eea0b26858d89c756c2e74f
   url: oci://ghcr.io/home-operations/charts-mirror/metrics-server

--- a/kubernetes/apps/base/multus/ocirepository.yaml
+++ b/kubernetes/apps/base/multus/ocirepository.yaml
@@ -10,4 +10,5 @@ spec:
     operation: copy
   ref:
     tag: 1.3.2
+    digest: sha256:a864073d652939644b3c076633b9d81e85be864e25e255fd350fad184bd36a16
   url: oci://ghcr.io/bjw-s-labs/helm/multus

--- a/kubernetes/apps/base/openebs/ocirepository.yaml
+++ b/kubernetes/apps/base/openebs/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 4.4.0
+    digest: sha256:5aaf304bb3d0ce863b01b2f93d66f7862b90d9b5c4685d4f512c0ae15dd4223d
   url: oci://ghcr.io/openebs/charts/openebs

--- a/kubernetes/apps/base/prometheus-operator-crds/ocirepository.yaml
+++ b/kubernetes/apps/base/prometheus-operator-crds/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 27.0.0
+    digest: sha256:bc2719e9c59e9ceaeddf88bfea697e064b1c756dc57af46d46cfea6520681e38
   url: oci://ghcr.io/prometheus-community/charts/prometheus-operator-crds

--- a/kubernetes/apps/base/reloader/ocirepository.yaml
+++ b/kubernetes/apps/base/reloader/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 2.2.12
+    digest: sha256:1efe694acf4ada31404232a1889126ddc92789bddca3054f74f3b2e8ded1116a
   url: oci://ghcr.io/stakater/charts/reloader

--- a/kubernetes/apps/base/spegel/ocirepository.yaml
+++ b/kubernetes/apps/base/spegel/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.7.1
+    digest: sha256:9efb90dbec90f3ffda195196eaa151cd1a6c2c30d44d59bb2c0853edf08d4430
   url: oci://ghcr.io/spegel-org/helm-charts/spegel

--- a/kubernetes/apps/base/victoria-logs-collector/ocirepository.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.3.6
+    digest: sha256:6b7d73c14e1fb20c24bf5cb13880575f13572961560f60be504f256de3497659
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-collector

--- a/kubernetes/apps/base/victoria-logs/ocirepository.yaml
+++ b/kubernetes/apps/base/victoria-logs/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.2.7
+    digest: sha256:40d8bb343ee8ecb421e762f9c5b3366ce1a23dc30259ad3374ab70c258d34f8e
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-logs-cluster

--- a/kubernetes/apps/base/victoria-metrics/ocirepository.yaml
+++ b/kubernetes/apps/base/victoria-metrics/ocirepository.yaml
@@ -11,4 +11,5 @@ spec:
     operation: copy
   ref:
     tag: 0.81.0
+    digest: sha256:b8f7f31f3ee1ce7cb70fa6713c8f58519afe68d15a2cd0b9ed5a4b80c4c1de22
   url: oci://ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack

--- a/kubernetes/apps/production/cert-manager/cert-manager-webhook-ovh.yaml
+++ b/kubernetes/apps/production/cert-manager/cert-manager-webhook-ovh.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/aureq/charts/cert-manager-webhook-ovh
             tag: 0.9.13
+            digest: sha256:af2391900ae7859e7514ab962d6e5dac8f0f7ea479fb032251caba81b903177e
       target:
         kind: OCIRepository
         name: cert-manager-webhook-ovh

--- a/kubernetes/apps/production/cert-manager/cert-manager.yaml
+++ b/kubernetes/apps/production/cert-manager/cert-manager.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=quay.io/jetstack/charts/cert-manager
             tag: v1.19.4
+            digest: sha256:135b97727e98ab0af229c2dceaf2e2c3c074a7b83495c6e09a1697c85e5ef6c7
       target:
         kind: OCIRepository
         name: cert-manager

--- a/kubernetes/apps/production/cnpg-system/cloudnative-pg.yaml
+++ b/kubernetes/apps/production/cnpg-system/cloudnative-pg.yaml
@@ -29,6 +29,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/charts/cloudnative-pg
             tag: 0.28.2
+            digest: sha256:395480811b5472e8e3c3f1d98d838596019d50b109e26bb0eb537c227fba679a
       target:
         kind: OCIRepository
         name: cloudnative-pg

--- a/kubernetes/apps/production/default/echo.yaml
+++ b/kubernetes/apps/production/default/echo.yaml
@@ -32,6 +32,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/home-operations/charts/echo
             tag: 0.1.3
+            digest: sha256:a7775879981d02b2fca1cac61dc49db2a9d86fe305594808c163d0fdfc5f9f3e
       target:
         kind: OCIRepository
         name: echo

--- a/kubernetes/apps/production/envoy-system/envoy-gateway.yaml
+++ b/kubernetes/apps/production/envoy-system/envoy-gateway.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=mirror.gcr.io/envoyproxy/gateway-helm
             tag: 1.7.0
+            digest: sha256:fdc01017304bc676fb7097d1fe8ceda5cc1c9673bf1c01a7576898623b3310f7
       target:
         kind: OCIRepository
         name: envoy-gateway

--- a/kubernetes/apps/production/external-secrets/external-secrets.yaml
+++ b/kubernetes/apps/production/external-secrets/external-secrets.yaml
@@ -33,6 +33,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/external-secrets/charts/external-secrets
             tag: 2.2.0
+            digest: sha256:feb252e996e2ce31ea015a1e098f2c5d438389a0a2fc1f43659b3f5421046f6f
       target:
         kind: OCIRepository
         name: external-secrets

--- a/kubernetes/apps/production/kube-system/descheduler.yaml
+++ b/kubernetes/apps/production/kube-system/descheduler.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/home-operations/charts-mirror/descheduler
             tag: 0.36.0
+            digest: sha256:b1f1d872bf64ebf88437467f4a2217bd08cf0e3cd07861e281f20b7b578d5c18
       target:
         kind: OCIRepository
         name: descheduler

--- a/kubernetes/apps/production/kube-system/metrics-server.yaml
+++ b/kubernetes/apps/production/kube-system/metrics-server.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/home-operations/charts-mirror/metrics-server
             tag: 3.13.0
+            digest: sha256:40f86072c24a94faa1ae0035fa4688364f97cd7d9eea0b26858d89c756c2e74f
       target:
         kind: OCIRepository
         name: metrics-server

--- a/kubernetes/apps/production/kube-system/reloader.yaml
+++ b/kubernetes/apps/production/kube-system/reloader.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/stakater/charts/reloader
             tag: 2.2.12
+            digest: sha256:1efe694acf4ada31404232a1889126ddc92789bddca3054f74f3b2e8ded1116a
       target:
         kind: OCIRepository
         name: reloader

--- a/kubernetes/apps/production/kube-system/spegel.yaml
+++ b/kubernetes/apps/production/kube-system/spegel.yaml
@@ -32,6 +32,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/spegel-org/helm-charts/spegel
             tag: 0.7.1
+            digest: sha256:9efb90dbec90f3ffda195196eaa151cd1a6c2c30d44d59bb2c0853edf08d4430
       target:
         kind: OCIRepository
         name: spegel

--- a/kubernetes/apps/production/o11y/grafana-operator.yaml
+++ b/kubernetes/apps/production/o11y/grafana-operator.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/grafana/helm-charts/grafana-operator
             tag: 5.24.0
+            digest: sha256:4f69cdaecfed2cc61d4e5f4a8e7142795e9b00997e4bcbd37a8c154a225a2f1f
       target:
         kind: OCIRepository
         name: grafana-operator

--- a/kubernetes/apps/production/o11y/prometheus-operator-crds.yaml
+++ b/kubernetes/apps/production/o11y/prometheus-operator-crds.yaml
@@ -29,6 +29,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/prometheus-community/charts/prometheus-operator-crds
             tag: 27.0.0
+            digest: sha256:bc2719e9c59e9ceaeddf88bfea697e064b1c756dc57af46d46cfea6520681e38
       target:
         kind: OCIRepository
         name: prometheus-operator-crds

--- a/kubernetes/apps/production/o11y/victoria-logs-collector.yaml
+++ b/kubernetes/apps/production/o11y/victoria-logs-collector.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/victoriametrics/helm-charts/victoria-logs-collector
             tag: 0.3.6
+            digest: sha256:6b7d73c14e1fb20c24bf5cb13880575f13572961560f60be504f256de3497659
       target:
         kind: OCIRepository
         name: victoria-logs-collector

--- a/kubernetes/apps/production/o11y/victoria-logs.yaml
+++ b/kubernetes/apps/production/o11y/victoria-logs.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/victoriametrics/helm-charts/victoria-logs-cluster
             tag: 0.2.7
+            digest: sha256:40d8bb343ee8ecb421e762f9c5b3366ce1a23dc30259ad3374ab70c258d34f8e
       target:
         kind: OCIRepository
         name: victoria-logs

--- a/kubernetes/apps/production/o11y/victoria-metrics.yaml
+++ b/kubernetes/apps/production/o11y/victoria-metrics.yaml
@@ -31,6 +31,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/victoriametrics/helm-charts/victoria-metrics-k8s-stack
             tag: 0.81.0
+            digest: sha256:b8f7f31f3ee1ce7cb70fa6713c8f58519afe68d15a2cd0b9ed5a4b80c4c1de22
       target:
         kind: OCIRepository
         name: victoria-metrics

--- a/kubernetes/apps/production/openebs-system/openebs.yaml
+++ b/kubernetes/apps/production/openebs-system/openebs.yaml
@@ -29,6 +29,7 @@ spec:
           ref:
             # renovate: datasource=docker depName=ghcr.io/openebs/charts/openebs
             tag: 4.4.0
+            digest: sha256:5aaf304bb3d0ce863b01b2f93d66f7862b90d9b5c4685d4f512c0ae15dd4223d
       target:
         kind: OCIRepository
         name: openebs

--- a/renovate.json
+++ b/renovate.json
@@ -22,6 +22,18 @@
       "/(^|/)kustomization\\.ya?ml(?:\\.j2)?$/"
     ]
   },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "OCIRepository Tags and Digests",
+      "managerFilePatterns": ["/(^|/)kubernetes/apps/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*\\n\\s*digest:\\s*\"?(?<currentDigest>sha256:[a-f0-9]{64})\"?"
+      ],
+      "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
+      "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    }
+  ],
   "packageRules": [
     {
       "description": "Split base Kubernetes updates into their own PRs",


### PR DESCRIPTION
Closes #102.

Flux gives `ref.digest` precedence over `ref.tag`, so once renovate digest-pins a base `OCIRepository` (the shared preset extends `docker:pinDigests`), the production tag patch is silently ignored - prod runs base's digest. Two charts (echo, cert-manager-webhook-ovh) were already in that state, and every other chart would join them as renovate touches base.

- All 16 production `OCIRepository` patches now pin `tag` **and** that tag's `digest` (resolved via `oras`, cross-checked against renovate's own base digests). A patched digest always beats base's, so the base/stage/prod strategy holds no matter what base carries.
- A local `customManagers` regex keeps the tag+digest pair in lockstep on production bump PRs.
- Staging needs nothing - it rides base, where the flux manager maintains tag+digest natively.

Zero-impact merge: for the two currently-overridden charts prod's tag equals base's (identical digest), and the rest had no base digest - nothing changes version on reconcile. Note the shared preset's regex still also matches the tag line, so renovate PRs may list these deps twice; edits converge, cosmetic only.