### PR TITLE
chore: unblock and gate renovate env PR flow

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -61,7 +61,7 @@
       "semanticCommitScope": "staging"
     },
     {
-      "description": "Split production Kubernetes updates into their own PRs; gate them on a Dependency Dashboard checkbox so base/staging merges and soaks first",
+      "description": "Split production Kubernetes updates into their own PRs and gate behind manual approval in the dashboard",
       "matchFileNames": [
         "kubernetes/apps/production/**"
       ],

--- a/renovate.json
+++ b/renovate.json
@@ -68,7 +68,6 @@
       "additionalBranchPrefix": "production-",
       "semanticCommitScope": "production",
       "dependencyDashboardApproval": true
-    },
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -69,12 +69,6 @@
       "semanticCommitScope": "production",
       "dependencyDashboardApproval": true
     },
-    {
-      "description": "netbox provider majors track NetBox server versions - bump deliberately after checking the server",
-      "matchDatasources": ["terraform-provider"],
-      "matchPackageNames": ["e-breuninger/netbox"],
-      "matchUpdateTypes": ["major"],
-      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["local>immich-app/.github:renovate-config"],
   "semanticCommits": "enabled",
+  "prHourlyLimit": 0,
   "flux": {
     "managerFilePatterns": [
       "/(^|/)kubernetes/.+\\.ya?ml(?:\\.j2)?$/"
@@ -60,12 +61,20 @@
       "semanticCommitScope": "staging"
     },
     {
-      "description": "Split production Kubernetes updates into their own PRs",
+      "description": "Split production Kubernetes updates into their own PRs; gate them on a Dependency Dashboard checkbox so base/staging merges and soaks first",
       "matchFileNames": [
         "kubernetes/apps/production/**"
       ],
       "additionalBranchPrefix": "production-",
-      "semanticCommitScope": "production"
+      "semanticCommitScope": "production",
+      "dependencyDashboardApproval": true
+    },
+    {
+      "description": "netbox provider majors track NetBox server versions - bump deliberately after checking the server",
+      "matchDatasources": ["terraform-provider"],
+      "matchPackageNames": ["e-breuninger/netbox"],
+      "matchUpdateTypes": ["major"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Two renovate behavior fixes found while diagnosing why production dependency PRs never open (only base):

- **`prHourlyLimit: 0`** - detection was fine (the dashboard queues every `production-*` branch), but the default 2-PRs-per-hour budget inside the once-a-week schedule window meant the queue never drained past the `base-*` and tooling branches. Production PRs were starved, not missing.
- **`dependencyDashboardApproval` on the production rule** - now that they *can* open, gate them: production updates wait as a checkbox on the [Dependency Dashboard](../issues/13) until ticked. That's the promotion flow - base/staging merges and soaks first, production is a deliberate click. (Renovate has no native "after PR X merges" trigger; this is the closest native gate.)
