### PR TITLE
chore: fix production renovate gaps (pinDigest phantom + netbird image pin)

### DIFF
--- a/kubernetes/apps/production/netbird/netbird-router.yaml
+++ b/kubernetes/apps/production/netbird/netbird-router.yaml
@@ -14,3 +14,19 @@ spec:
     name: flux-system
     namespace: flux-system
   targetNamespace: netbird
+  patches:
+    - patch: |-
+        apiVersion: apps/v1
+        kind: Deployment
+        metadata:
+          name: netbird-router
+        spec:
+          template:
+            spec:
+              containers:
+                - name: netbird
+                  # renovate: datasource=docker depName=netbirdio/netbird
+                  image: netbirdio/netbird:0.73.2@sha256:201ce4bfa4f72c458db8a75db2dbb6929bed3a16f5150ce44f9ef3a49998a3fb
+      target:
+        kind: Deployment
+        name: netbird-router

--- a/renovate.json
+++ b/renovate.json
@@ -29,7 +29,8 @@
       "description": "OCIRepository Tags and Digests",
       "managerFilePatterns": ["/(^|/)kubernetes/apps/.+\\.ya?ml$/"],
       "matchStrings": [
-        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*\\n\\s*digest:\\s*\"?(?<currentDigest>sha256:[a-f0-9]{64})\"?"
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*tag:\\s*\"?(?<currentValue>[^\"\\s]+)\"?\\s*\\n\\s*digest:\\s*\"?(?<currentDigest>sha256:[a-f0-9]{64})\"?",
+        "datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s*\\n\\s*(?:-\\s+)?image: \\S+?:(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"

--- a/renovate.json
+++ b/renovate.json
@@ -68,6 +68,14 @@
       "additionalBranchPrefix": "production-",
       "semanticCommitScope": "production",
       "dependencyDashboardApproval": true
+    },
+    {
+      "description": "Digests in production patches are managed by the custom manager",
+      "matchFileNames": [
+        "kubernetes/apps/production/**"
+      ],
+      "matchUpdateTypes": ["pinDigest"],
+      "enabled": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -71,8 +71,10 @@
       "dependencyDashboardApproval": true
     },
     {
-      "description": "Digests in production patches are managed by the custom manager",
+      "description": "Digests in env overlay patches are managed by the custom manager",
       "matchFileNames": [
+        "kubernetes/apps/development/**",
+        "kubernetes/apps/staging/**",
         "kubernetes/apps/production/**"
       ],
       "matchUpdateTypes": ["pinDigest"],


### PR DESCRIPTION
Two production-side renovate gaps:

**Disable `pinDigest` for production patches.** The dashboard shows `chore(production): pin dependencies` even though every patch already pins tag + digest - the shared preset's tag-only regex extraction can't see the `digest:` line, so `docker:pinDigests` offers phantom pins whose autoreplace would write `tag: x.y.z@sha256:...` (invalid for `OCIRepository.spec.ref.tag`) across 16 patches. Version bumps and digest refreshes via the custom manager are unaffected; the phantom entry disappears next run.

**Pin the netbird-router image for production.** The router image wasn't env-split, so a base bump (0.74.4 is queued) would roll both envs' routing peers at once. Production now pins it via a kustomize patch on the Flux Kustomization, staging keeps riding base, and a second custom-manager matchString updates `image: repo:tag@sha256:...` lines tag+digest in lockstep - same promotion flow as the charts.