### PR TITLE
ci: wire up the terraform plan workflow

### DIFF
--- a/.github/actions/netbird-connect/action.yml
+++ b/.github/actions/netbird-connect/action.yml
@@ -1,0 +1,58 @@
+name: Connect to NetBird
+description: >-
+  Install the NetBird client and join the mesh with a setup key the caller
+  already read (and masked). The key is minted by netbird/cluster
+  (o11y-<env>-ci), so that module must be applied before this runs.
+
+inputs:
+  setup-key:
+    description: NetBird setup key (plaintext; mask it before passing).
+    required: true
+  management-url:
+    description: NetBird management URL.
+    required: false
+    default: https://api.netbird.io
+  hostname:
+    description: Peer hostname to register the runner as.
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    - name: Install NetBird client
+      shell: bash
+      run: |
+        set -euo pipefail
+        curl -fsSL https://pkgs.netbird.io/install.sh | sh
+        netbird version
+
+    - name: Connect to NetBird
+      shell: bash
+      env:
+        NB_SETUP_KEY: ${{ inputs.setup-key }}
+        NB_MANAGEMENT_URL: ${{ inputs.management-url }}
+        NB_HOSTNAME: ${{ inputs.hostname }}
+      run: |
+        set -euo pipefail
+        args=(--setup-key "$NB_SETUP_KEY" --management-url "$NB_MANAGEMENT_URL")
+        if [ -n "$NB_HOSTNAME" ]; then
+          args+=(--hostname "$NB_HOSTNAME")
+        fi
+        sudo netbird up "${args[@]}"
+
+    - name: Wait for NetBird connection
+      shell: bash
+      run: |
+        set -euo pipefail
+        for _ in $(seq 1 30); do
+          if sudo netbird status 2>/dev/null | grep -qE "Management:[[:space:]]+Connected"; then
+            sudo netbird status --detail || true
+            echo "NetBird connected."
+            exit 0
+          fi
+          sleep 2
+        done
+        echo "NetBird did not reach the Connected state in time." >&2
+        sudo netbird status --detail || true
+        exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ name: Infra (Terraform)
 # target, the connection hairpins; re-run the job.
 #
 # Prerequisites (out-of-band, once):
-#   - Repo secret OP_TF_O11Y_ENV: a 1Password service-account token with read
+#   - Repo secret OP_TF_O11Y: a 1Password service-account token with read
 #     access to o11y_tf, o11y_tf_staging, o11y_tf_prod, shared_tf.
 #   - netbird/cluster applied per env (mints the CI setup key).
 #   - Re-enable the workflow: gh workflow enable deploy.yml
@@ -49,7 +49,7 @@ jobs:
     env:
       ENVIRONMENT: ${{ matrix.environment }}
       TF_VAR_env: ${{ matrix.environment }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TF_O11Y_ENV }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TF_O11Y }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,27 +1,57 @@
-name: Deploy
+name: Infra (Terraform)
+
+# Plans every Terragrunt module on PRs and on manual dispatch (drift check).
+# One deployment tree drives both environments (ENVIRONMENT selects state +
+# vault), so every change plans against both. Applies stay operator-run.
+#
+# The talos + kubernetes/helm modules refresh against control-plane private IPs,
+# so jobs join the NetBird mesh with a CI setup key read from the netbird/cluster
+# state (o11y-<env>-ci peer; policy grants apid 50000 + kube-apiserver 6443).
+# Known flake: if the elected vRack routing peer is the same CP the providers
+# target, the connection hairpins; re-run the job.
+#
+# Prerequisites (out-of-band, once):
+#   - Repo secret OP_TF_O11Y_ENV: a 1Password service-account token with read
+#     access to o11y_tf, o11y_tf_staging, o11y_tf_prod, shared_tf.
+#   - netbird/cluster applied per env (mints the CI setup key).
+#   - Re-enable the workflow: gh workflow enable deploy.yml
+
 on:
-  push:
-    branches: [main]
   pull_request:
     branches: [main]
+    paths:
+      - 'deployment/**'
+      - '.mise/config.toml'
+      - '.github/actions/netbird-connect/**'
+      - '.github/workflows/deploy.yml'
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
-  ENVIRONMENT: ${{ github.ref == 'refs/heads/main' && 'prod' || 'dev' }}
   TG_NON_INTERACTIVE: 'true'
 
 jobs:
-  deploy:
-    name: Deploy
+  plan:
+    name: Plan ${{ matrix.environment }}
+    # Fork PRs have no secrets and no mesh access.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: [staging, production]
     env:
-      TF_VAR_stage: ${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.number) || '' }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ github.ref == 'refs/heads/main' && secrets.OP_TF_PROD_ENV || secrets.OP_TF_DEV_ENV }}
+      ENVIRONMENT: ${{ matrix.environment }}
+      TF_VAR_env: ${{ matrix.environment }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TF_O11Y_ENV }}
     steps:
-      - name: Checkout code
+      - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           persist-credentials: false
@@ -41,6 +71,24 @@ jobs:
         with:
           github_token: ${{ steps.token.outputs.token }}
 
-      - name: Deploy All
-        working-directory: ${{ github.workspace }}/deployment
-        run: mise run tf:apply
+      - name: Init
+        run: mise run tf:init
+
+      - name: Read the CI mesh setup key from state
+        id: nb
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          key=$(mise run tg run --working-dir deployment/modules/netbird/cluster output -- -raw ci_setup_key)
+          echo "::add-mask::$key"
+          echo "setup-key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Connect to NetBird
+        uses: ./.github/actions/netbird-connect
+        with:
+          setup-key: ${{ steps.nb.outputs.setup-key }}
+          hostname: gha-plan-${{ matrix.environment }}-${{ github.run_id }}
+
+      - name: Plan
+        run: mise run tf:plan
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,10 @@ name: Infra (Terraform)
 # target, the connection hairpins; re-run the job.
 #
 # Prerequisites (out-of-band, once):
-#   - Repo secret OP_TF_O11Y: a 1Password service-account token with read
-#     access to o11y_tf, o11y_tf_staging, o11y_tf_prod, shared_tf.
+#   - Per-env repo secrets OP_TF_O11Y_STAGING_ENV / OP_TF_O11Y_PROD_ENV: the
+#     1PASS_TF_SA_O11Y_READ service-account token for each env (stored in the
+#     o11y_tf_{staging,prod} vaults). Each needs read on o11y_tf (OVH + TF S3
+#     state), its own o11y_tf_<env>, and shared_tf (NetBird, NetBox).
 #   - netbird/cluster applied per env (mints the CI setup key).
 #   - Re-enable the workflow: gh workflow enable deploy.yml
 
@@ -49,7 +51,7 @@ jobs:
     env:
       ENVIRONMENT: ${{ matrix.environment }}
       TF_VAR_env: ${{ matrix.environment }}
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_TF_O11Y }}
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ matrix.environment == 'production' && secrets.OP_TF_O11Y_PROD_ENV || secrets.OP_TF_O11Y_STAGING_ENV }}
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.mise/config.toml
+++ b/.mise/config.toml
@@ -90,8 +90,9 @@ chmod 600 {{config_root}}/.private/${ENVIRONMENT}/kubeconfig
 description = "Fetch kubeconfig for $ENVIRONMENT into .private/<env>/ (server = HA mesh endpoint kube.<zone>)"
 dir = "{{cwd}}"
 
+# CI authenticates with a service-account token, which op rejects alongside --account.
 [tasks.tg]
-run = "op run --account 'team-futo.1password.com' '--env-file={{config_root}}/deployment/.env' -- terragrunt"
+run = "op run {% if get_env(name='OP_SERVICE_ACCOUNT_TOKEN', default='') == '' %}--account 'team-futo.1password.com' {% endif %}'--env-file={{config_root}}/deployment/.env' -- terragrunt"
 description = "Wrapper for terragrunt"
 dir = "{{cwd}}"
 

--- a/deployment/modules/netbird/cluster/netbird.tf
+++ b/deployment/modules/netbird/cluster/netbird.tf
@@ -200,6 +200,38 @@ resource "netbird_network_resource" "k8s_egress" {
   enabled    = true
 }
 
+# CI peers (GitHub Actions runners): the infra workflow joins the mesh to reach the
+# talos + kube APIs for plan/apply. The key is read from this module's state by the
+# workflow; it never lands in 1Password. Ephemeral: runners are transient.
+resource "netbird_group" "ci" {
+  name = "o11y-${var.env}-ci"
+}
+
+resource "netbird_setup_key" "ci" {
+  name           = "o11y-${var.env}-ci"
+  type           = "reusable"
+  ephemeral      = true
+  auto_groups    = [netbird_group.ci.id]
+  expiry_seconds = 0
+  usage_limit    = 0
+}
+
+resource "netbird_policy" "ci_to_o11y_resource" {
+  name    = "o11y-${var.env}-ci-to-resource"
+  enabled = true
+
+  rule {
+    name          = "ci-to-o11y-resource"
+    action        = "accept"
+    protocol      = "tcp"
+    enabled       = true
+    bidirectional = false
+    sources       = [netbird_group.ci.id]
+    destinations  = [netbird_group.o11y_resource.id]
+    ports         = ["50000", "6443"]
+  }
+}
+
 # Bootstrap-owned group holding the opc resource (live account name — verify if it changes).
 data "netbird_group" "bootstrap_opc" {
   name = "bootstrap-resources"

--- a/deployment/modules/netbird/cluster/outputs.tf
+++ b/deployment/modules/netbird/cluster/outputs.tf
@@ -11,6 +11,12 @@ output "k8s_routing_peer_setup_key" {
   value     = netbird_setup_key.k8s_routing_peer.key
 }
 
+# CI runner setup key; the infra workflow reads it from state to join the mesh.
+output "ci_setup_key" {
+  sensitive = true
+  value     = netbird_setup_key.ci.key
+}
+
 # Consumed by kubernetes/helm -> bootstrap-settings ConfigMap (Flux substitution).
 output "mesh_dns_zone" {
   value = local.mesh_dns_zone


### PR DESCRIPTION
Closes #53.

Rewrites the manually-disabled Deploy workflow (stale `prod`/`dev` env names, auto-apply on push, secrets that never existed) as **plan-only CI**, modeled on yucca's `infra.yml` and collapsed to this repo's single-tree/two-env shape:

- **PRs** touching `deployment/**` (or the tooling) plan **staging and production in parallel**; `workflow_dispatch` gives an on-demand drift check. No apply job: applies stay operator-run.
- The talos + kubernetes/helm providers refresh against CP private IPs, so each job **joins the NetBird mesh** via a new `netbird-connect` composite action. The CI identity is Terraform-managed in `netbird/cluster` (`o11y-<env>-ci` group + ephemeral reusable setup key + a policy for apid `50000` / kube-apiserver `6443`), and the workflow reads the key **from module state** - no 1Password write path needed.
- The mise `tg` task now drops `op run --account` when `OP_SERVICE_ACCOUNT_TOKEN` is set (op rejects the combination); the local operator flow is unchanged.
- The workflow keeps the `deploy.yml` path on purpose: it inherits the existing `disabled_manually` state, so nothing runs on merge until explicitly enabled.

Before enabling (out-of-band):
1. Create a 1Password service account with read access to `o11y_tf`, `o11y_tf_staging`, `o11y_tf_prod`, `shared_tf`; store it as repo secret `OP_TF_O11Y_ENV`.
2. Apply `netbird/cluster` per env to mint the CI setup keys. ⚠️ This is the first `netbird/cluster` apply since bootstrap renamed its groups - confirm the live `bootstrap-resources` group name first (the `bootstrap_opc` data source refreshes on apply).
3. `gh workflow enable deploy.yml`

Known flake, documented in the header: if the elected vRack routing peer is the CP the providers target, the connection hairpins - re-run the job.