### PR TITLE
feat: browsable VM/VL mesh UIs and yucca grafana dashboards

### DIFF
--- a/kubernetes/apps/base/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/base/grafana/dashboards/kustomization.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./yucca.yaml

--- a/kubernetes/apps/base/grafana/dashboards/yucca.yaml
+++ b/kubernetes/apps/base/grafana/dashboards/yucca.yaml
@@ -1,0 +1,112 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-overview
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: yucca-overview.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-michael
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: yucca-michael.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-telemetry-pipeline
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: yucca-telemetry-pipeline.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-father-kubernetes
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: father-kubernetes.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-spice-ceph-health
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: spice-ceph-health.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-spice-rgw-capacity
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: spice-rgw-capacity.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-spice-nodes
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: spice-nodes.json
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanadashboard_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaDashboard
+metadata:
+  name: yucca-fabric-htz-fsn1
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  resyncPeriod: 10m
+  oci:
+    reference: ghcr.io/immich-app/yucca/dashboards:latest
+    path: fabric-htz-fsn1.json

--- a/kubernetes/apps/base/grafana/kustomization.yaml
+++ b/kubernetes/apps/base/grafana/kustomization.yaml
@@ -5,3 +5,4 @@ resources:
   - ./externalsecret.yaml
   - ./grafana.yaml
   - ./datasource.yaml
+  - ./dashboards

--- a/kubernetes/apps/base/victoria-logs/httproute-mesh.yaml
+++ b/kubernetes/apps/base/victoria-logs/httproute-mesh.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vlogs-mesh
+spec:
+  parentRefs:
+    - name: mesh
+      namespace: envoy-system
+  hostnames:
+    - vlogs.${BOOTSTRAP_MESH_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /select/vmui/
+            statusCode: 302
+    - backendRefs:
+        - name: victoria-logs-vlselect
+          port: 9471

--- a/kubernetes/apps/base/victoria-logs/kustomization.yaml
+++ b/kubernetes/apps/base/victoria-logs/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute-mesh.yaml

--- a/kubernetes/apps/base/victoria-metrics/httproute-mesh.yaml
+++ b/kubernetes/apps/base/victoria-metrics/httproute-mesh.yaml
@@ -1,0 +1,27 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: vmetrics-mesh
+spec:
+  parentRefs:
+    - name: mesh
+      namespace: envoy-system
+  hostnames:
+    - vmetrics.${BOOTSTRAP_MESH_DOMAIN}
+  rules:
+    - matches:
+        - path:
+            type: Exact
+            value: /
+      filters:
+        - type: RequestRedirect
+          requestRedirect:
+            path:
+              type: ReplaceFullPath
+              replaceFullPath: /select/0/vmui/
+            statusCode: 302
+    - backendRefs:
+        - name: vmselect-victoria-metrics
+          port: 8481

--- a/kubernetes/apps/base/victoria-metrics/kustomization.yaml
+++ b/kubernetes/apps/base/victoria-metrics/kustomization.yaml
@@ -4,3 +4,4 @@ kind: Kustomization
 resources:
   - ./helmrelease.yaml
   - ./ocirepository.yaml
+  - ./httproute-mesh.yaml

--- a/renovate.json
+++ b/renovate.json
@@ -34,6 +34,16 @@
       ],
       "datasourceTemplate": "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
       "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}"
+    },
+    {
+      "customType": "regex",
+      "description": "GrafanaDashboard OCI references (tag + digest)",
+      "managerFilePatterns": ["/(^|/)kubernetes/apps/.+\\.ya?ml$/"],
+      "matchStrings": [
+        "reference:\\s+(?<depName>\\S+?):(?<currentValue>[^@\\s]+)@(?<currentDigest>sha256:[a-f0-9]{64})"
+      ],
+      "datasourceTemplate": "docker",
+      "versioningTemplate": "docker"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
Two related observability additions, both on the mesh only.

## victoria-metrics / victoria-logs UIs over the mesh
HTTPRoutes on the mesh gateway expose the vmselect and vlselect `vmui`
interfaces at `vmetrics.${BOOTSTRAP_MESH_DOMAIN}` and `vlogs.${BOOTSTRAP_MESH_DOMAIN}`,
each redirecting the root path to its UI. Read-only, unauthenticated, matching
the existing vmauth exposure.

## yucca grafana dashboards
`GrafanaDashboard` resources import each dashboard from the public
`ghcr.io/immich-app/yucca/dashboards` artifact (source: immich-app/yucca#294),
names prefixed `yucca-`. Tracks the mutable `:latest` tag and relies on the
operator's `resyncPeriod` to roll out new pushes; a renovate customManager is
kept for any reference later pinned to a digest.