### PR TITLE
feat: o11y stack tuning, yucca dashboard folder, and docs

### DIFF
--- a/docs/05-shipping-metrics-guide.md
+++ b/docs/05-shipping-metrics-guide.md
@@ -1,0 +1,138 @@
+# Shipping metrics to the central store
+
+This cluster is the central VictoriaMetrics store for all FUTO clusters. A remote cluster does not push into a special API: it runs its own `vmagent` and **remote-writes** the standard Prometheus format to an ingestion gateway here. This guide covers the two network paths in, the config each needs, and how to verify data is landing.
+
+Both paths terminate at a `vmauth` gateway that proxies to the same `vminsert` tier, so the ingestion API, the label rules, and the resulting data are identical no matter which you pick. The only differences are the hostname, the transport, and whether a token is required.
+
+## The two paths
+
+| | Over the NetBird mesh | Over the internet |
+|---|---|---|
+| Gateway hostname | `vmauth.<mesh-domain>` | `vmauth.<app-domain>` |
+| Envoy gateway | `mesh` (mesh-only VIP) | `envoy` (public, via OVH IPLB) |
+| Auth | none; the NetBird ACL is the gate | shared bearer token |
+| Transport | private overlay, never leaves the mesh | public internet, TLS at Envoy |
+| Use when | the remote cluster is already a mesh peer | the remote cluster is not on the mesh |
+
+Prefer the mesh path for clusters already joined to the FUTO NetBird mesh: there is no token to distribute or rotate, and the traffic never traverses the public internet. Use the internet path for anything not on the mesh. Both may be used at once; they write to the same store.
+
+### Per-environment endpoints
+
+| | staging | production |
+|---|---|---|
+| Mesh gateway | `vmauth.staging.o11y.futo.network` | `vmauth.o11y.futo.network` |
+| Public gateway | `vmauth.staging.futostatus.com` | `vmauth.futostatus.com` |
+
+The metrics remote-write path is the same on every host:
+
+```text
+/insert/0/prometheus/api/v1/write
+```
+
+(`0` is the VictoriaMetrics tenant; everything lands in a single tenant, see Labels below.)
+
+## Prerequisites (both paths)
+
+* **A `vmagent` with a persistent disk buffer.** The central store is a single point of failure for observability; a per-remote disk buffer means a central outage replays on recovery instead of dropping data. Give `vmagent` a PVC and point `-remoteWrite.tmpDataPath` at it (or, for Prometheus, rely on its WAL and tune `queue_config`).
+* **The mandatory `cluster` external label** (plus `env` and `region`). See Labels.
+
+## Option A: over the NetBird mesh
+
+The remote cluster must be a NetBird peer whose group is permitted by ACL to reach this cluster's mesh gateway, and its `vmagent` must egress through a mesh interface and resolve `vmauth.<mesh-domain>` via mesh DNS. See the NetBird section of the [infrastructure guide](02-infrastructure-architecture-guide.md) for how peers and ACLs are modelled; on this side, `external-secrets` reaching the bootstrap 1Password Connect is the reference pattern (a Multus egress interface plus mesh DNS).
+
+No token is needed: the mesh ACL is the only gate. The gateway still terminates TLS with a publicly-trusted `*.<mesh-domain>` certificate, so `https://` works with no custom CA.
+
+```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAgent
+metadata:
+  name: central-forwarder
+spec:
+  externalLabels:
+    cluster: my-cluster   # unique per remote, mandatory
+    env: prod
+    region: eu-west
+  remoteWrite:
+    - url: https://vmauth.o11y.futo.network/insert/0/prometheus/api/v1/write
+  extraArgs:
+    remoteWrite.tmpDataPath: /vmagent-buffer
+  # ...plus a PVC mounted at /vmagent-buffer for the disk buffer
+```
+
+## Option B: over the internet
+
+The public gateway rejects anonymous requests, so a **shared bearer token** is required. It lives in 1Password as item `O11Y_VICTORIAMETRICS_VMAUTH_PASSWORD` (field `password`). Clusters that share the vault can pull it with an ExternalSecret; otherwise create the Secret by hand. Rotating the token for everyone is a single edit to that vault item.
+
+```yaml
+apiVersion: operator.victoriametrics.com/v1beta1
+kind: VMAgent
+metadata:
+  name: central-forwarder
+spec:
+  externalLabels:
+    cluster: my-cluster   # unique per remote, mandatory
+    env: prod
+    region: eu-west
+  remoteWrite:
+    - url: https://vmauth.futostatus.com/insert/0/prometheus/api/v1/write
+      bearerTokenSecret:
+        name: o11y-remote-write-token   # a Secret holding the vault token
+        key: token
+  extraArgs:
+    remoteWrite.tmpDataPath: /vmagent-buffer
+  # ...plus a PVC mounted at /vmagent-buffer for the disk buffer
+```
+
+If the remote runs Prometheus rather than `vmagent`, the equivalent is:
+
+```yaml
+global:
+  external_labels:
+    cluster: my-cluster
+    env: prod
+    region: eu-west
+remote_write:
+  - url: https://vmauth.futostatus.com/insert/0/prometheus/api/v1/write
+    authorization:
+      type: Bearer
+      credentials_file: /etc/o11y/token
+```
+
+## Labels
+
+Everything lands in one tenant, distinguished by labels rather than VictoriaMetrics multitenancy: one organization, mutual trust, everything queryable together. Every remote `vmagent` must set:
+
+* **`cluster`** (mandatory) - a name unique to the remote cluster, so series never collide with another cluster's. Cheap to enforce now, painful to retrofit.
+* **`env`** and **`region`** - conventional, so dashboards and alerts can slice by environment and location.
+
+## Verify data is arriving
+
+From the central side, query for the remote's series. Over the mesh (no token), the browsable UI is at `https://vmetrics.<mesh-domain>/select/0/vmui/`, or query the API directly:
+
+```bash
+curl -s 'https://vmauth.o11y.futo.network/select/0/prometheus/api/v1/query' \
+  --data-urlencode 'query=count(up{cluster="my-cluster"})'
+```
+
+Over the internet, the same query with the token:
+
+```bash
+curl -s -H "Authorization: Bearer $TOKEN" \
+  'https://vmauth.futostatus.com/select/0/prometheus/api/v1/query' \
+  --data-urlencode 'query=count(up{cluster="my-cluster"})'
+```
+
+A non-zero count means the remote's series are landing. If it is zero, check the remote `vmagent`'s own `vmagent_remotewrite_*` metrics for send errors, and confirm the `cluster` label is set.
+
+## Logs, on the same gateways
+
+Logs ride the identical `vmauth` hostnames (VictoriaLogs sits behind the same gateways). Point a log shipper at `https://vmauth.<host>/insert/<format>/...`, where `<format>` is one of `native`, `jsonline`, `opentelemetry`, `loki`, or `elasticsearch`; read back with `/select/logsql/...`. Auth is the same as for metrics: none on the mesh, bearer token on the internet.
+
+## What backs this centrally
+
+For maintainers, the ingestion config lives in `kubernetes/apps/base/victoria-metrics-users/`:
+
+* `vmuser-remote-clusters.yaml` - the `VMUser` behind the public gateway. It holds the shared token (via ExternalSecret) and the allowed path set: metrics and logs insert **and** select (remote clusters can read back, not only write).
+* `vmauth-mesh-unauth.yaml` - the unauthenticated `mesh-unauth` `VMAuth` on the mesh gateway, with the same path set exposed through `unauthorizedUserAccessSpec`.
+
+The public gateway itself is the `vmauth` defined in the VictoriaMetrics release (`kubernetes/apps/base/victoria-metrics/helmrelease.yaml`), reached at `vmauth.<CLUSTER_APP_DOMAIN>`.

--- a/docs/06-dashboards-guide.md
+++ b/docs/06-dashboards-guide.md
@@ -1,0 +1,67 @@
+# Grafana dashboards: build and deploy
+
+Dashboards are not committed to Grafana or to this repo as provisioning files. They are authored in the [immich-app/yucca](https://github.com/immich-app/yucca) repo, built once by CI into a single OCI artifact on GHCR, and imported here by the grafana-operator. Two repos, one artifact, no manual Grafana edits that survive a pod restart.
+
+```text
+yucca repo                          GHCR                         o11y (this repo)
+dashboards/*.json  --CI (oras)-->   ghcr.io/immich-app/yucca/    GrafanaDashboard CRs
+                                    dashboards:latest       -->  grafana-operator --> Grafana
+```
+
+## Building the artifact (yucca repo)
+
+Source of truth is `dashboards/*.json` in yucca. The workflow [`.github/workflows/dashboards.yml`](https://github.com/immich-app/yucca/blob/main/.github/workflows/dashboards.yml) does two jobs:
+
+* **validate** (on every push and PR): each file must have a `uid`, a `title`, and at least one panel, and the **file name must equal `<uid>.json`**. o11y references each dashboard by that in-artifact path, so the name/uid match is load-bearing.
+* **push** (on merge to `main`, not on PRs): `oras` packages every JSON as one layer of a single artifact (type `application/vnd.grafana.dashboard+json`) and pushes it to `ghcr.io/immich-app/yucca/dashboards` with three tags:
+
+| Tag | Mutability | Purpose |
+|-----|-----------|---------|
+| `0.0.<run>` | immutable | pin an exact build |
+| `sha-<sha>` | immutable | trace back to a commit |
+| `latest` | moving | what o11y tracks by default |
+
+The GHCR package is public, so o11y pulls it anonymously (no pull secret). Triggers are `push`/`pull_request` scoped to `dashboards/**` plus the workflow file, and `workflow_dispatch`. See yucca's [`dashboards/README.md`](https://github.com/immich-app/yucca/blob/main/dashboards/README.md) for the dashboard set and label conventions.
+
+## Deploying on o11y (this repo)
+
+The consumer side is the bundle in [`kubernetes/apps/base/grafana/dashboards/`](../kubernetes/apps/base/grafana/dashboards):
+
+* `folder.yaml` - a `GrafanaFolder` named `yucca`, so all of these land in one Grafana folder.
+* `yucca.yaml` - one `GrafanaDashboard` per artifact file: `folderRef: yucca`, `instanceSelector` `dashboards: grafana`, `resyncPeriod: 10m`, `oci.reference` the `:latest` tag, and `oci.path` the `<uid>.json`.
+* `kustomization.yaml` - lists the two files above.
+
+The bundle is pulled in by `base/grafana`, which both environments deploy through the `grafana` Flux Kustomization (`dependsOn: grafana-operator`, so the CRD exists first). Because we track the mutable `:latest` tag, the operator re-pulls on its `resyncPeriod` and **content changes roll out with no o11y commit**. A dormant renovate customManager (`renovate.json`) exists only to keep the pair in lockstep if a `reference:` is ever pinned to `tag@sha256:...`.
+
+## Add or edit a dashboard, end to end
+
+**Edit an existing dashboard** (no o11y change needed):
+
+1. Edit it in Grafana, then export the JSON model (Share, then Export, then the dashboard JSON).
+2. In yucca, save over `dashboards/<uid>.json`, keeping the same `uid` (so the file name stays `<uid>.json`).
+3. Merge to `main`. CI validates and pushes; the o11y operator re-fetches within one `resyncPeriod` (~10m).
+
+**Add a new dashboard** (needs a change in both repos):
+
+1. In yucca: add `dashboards/<uid>.json` (file name must equal the uid), merge to `main`. CI adds it as a new layer of the artifact.
+2. In o11y: add a `GrafanaDashboard` entry to [`dashboards/yucca.yaml`](../kubernetes/apps/base/grafana/dashboards/yucca.yaml) with `path: <uid>.json`, `folderRef: yucca`, and a `metadata.name` (convention `yucca-<name>`), then reconcile. The new artifact layer alone does **not** create the dashboard: each file is imported by its own `GrafanaDashboard`, one per `path`.
+
+**Remove a dashboard**: delete its `GrafanaDashboard` entry in o11y (and the source file in yucca).
+
+## Verify
+
+After a reconcile, all dashboards should report synced:
+
+```bash
+kubectl get grafanadashboard -n o11y -o custom-columns=\
+'NAME:.metadata.name,SYNCED:.status.conditions[0].reason'
+```
+
+`ApplySuccessful` on each means the operator pulled the artifact and pushed it into Grafana; the dashboards then appear under the **yucca** folder in the UI.
+
+## Conventions and gotchas
+
+* **File name equals `<uid>.json`** on both sides (CI enforces it; o11y's `oci.path` references it).
+* Dashboards use a `$datasource` variable rather than a baked-in datasource UID, so they bind to whichever VictoriaMetrics datasource the operator provisions.
+* Pin `oci.reference` to `tag@sha256:...` only if you want renovate-driven, commit-gated rollout instead of the `:latest` auto-resync; the customManager then tracks it.
+* Michael's OTel metrics have dotted names; query them as `{__name__="http.server.request.count", ...}` in VictoriaMetrics.

--- a/kubernetes/apps/base/grafana/dashboards/folder.yaml
+++ b/kubernetes/apps/base/grafana/dashboards/folder.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/grafana.integreatly.org/grafanafolder_v1beta1.json
+apiVersion: grafana.integreatly.org/v1beta1
+kind: GrafanaFolder
+metadata:
+  name: yucca
+spec:
+  instanceSelector:
+    matchLabels:
+      dashboards: grafana
+  title: yucca
+  resyncPeriod: 10m

--- a/kubernetes/apps/base/grafana/dashboards/kustomization.yaml
+++ b/kubernetes/apps/base/grafana/dashboards/kustomization.yaml
@@ -2,4 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
+  - ./folder.yaml
   - ./yucca.yaml

--- a/kubernetes/apps/base/grafana/dashboards/yucca.yaml
+++ b/kubernetes/apps/base/grafana/dashboards/yucca.yaml
@@ -5,6 +5,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-overview
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -19,6 +20,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-michael
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -33,6 +35,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-telemetry-pipeline
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -47,6 +50,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-father-kubernetes
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -61,6 +65,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-spice-ceph-health
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -75,6 +80,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-spice-rgw-capacity
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -89,6 +95,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-spice-nodes
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana
@@ -103,6 +110,7 @@ kind: GrafanaDashboard
 metadata:
   name: yucca-fabric-htz-fsn1
 spec:
+  folderRef: yucca
   instanceSelector:
     matchLabels:
       dashboards: grafana

--- a/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs-collector/helmrelease.yaml
@@ -21,6 +21,13 @@ spec:
   values:
     fullnameOverride: victoria-logs-collector
 
+    resources:
+      requests:
+        cpu: 50m
+        memory: 128Mi
+      limits:
+        memory: 2Gi
+
     remoteWrite:
       - url: http://victoria-logs-vlinsert.o11y.svc.cluster.local:9481/insert/native
         maxDiskUsagePerURL: 10GB

--- a/kubernetes/apps/base/victoria-logs/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-logs/helmrelease.yaml
@@ -23,6 +23,12 @@ spec:
 
     vlstorage:
       replicaCount: 3
+      resources:
+        requests:
+          cpu: 200m
+          memory: 1Gi
+        limits:
+          memory: 12Gi
       retentionPeriod: ${CLUSTER_VMLOGS_RETENTION}
       persistentVolume:
         storageClassName: ${CLUSTER_VMLOGS_STORAGE_CLASS}
@@ -38,6 +44,12 @@ spec:
         enabled: true
 
     vlinsert:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 6Gi
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname
@@ -49,6 +61,12 @@ spec:
         enabled: true
 
     vlselect:
+      resources:
+        requests:
+          cpu: 100m
+          memory: 512Mi
+        limits:
+          memory: 6Gi
       topologySpreadConstraints:
         - maxSkew: 1
           topologyKey: kubernetes.io/hostname

--- a/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
+++ b/kubernetes/apps/base/victoria-metrics/helmrelease.yaml
@@ -207,3 +207,8 @@ spec:
 
     kubeProxy:
       enabled: true
+      vmScrape:
+        spec:
+          endpoints:
+            - port: http-metrics
+              scheme: http


### PR DESCRIPTION
Follow-ups from the staging pipeline review, plus two docs.

## Fixes and tuning
- **Scrape kube-proxy over HTTP** - Talos kube-proxy serves plain HTTP on `:10249`; the chart's default HTTPS scrape failed every target and flooded vmagent with warnings. Overridden to `scheme: http` (mirrors the `kubeEtcd` block). Recovers kube-proxy metrics.
- **VictoriaLogs resources** - the VL stack ran BestEffort (no requests/limits), first to be evicted under memory pressure. Added modest CPU/memory requests (well above observed peak) and generous memory limits as spike headroom: vlstorage 1Gi/12Gi, vlinsert & vlselect 512Mi/6Gi, collector 128Mi/2Gi. Requests reserve; limits are ceilings, so scheduling is unaffected on the 32Gi workers.

## Dashboards
- **yucca folder** - a `GrafanaFolder` plus `folderRef` on each dashboard, so they group under a `yucca` folder instead of General.

## Docs
- `docs/05-shipping-metrics-guide.md` - how remote clusters remote-write to the central store over the NetBird mesh or the public internet.
- `docs/06-dashboards-guide.md` - how dashboards are built into the yucca OCI artifact and deployed here by the grafana-operator.