### PR TITLE
feat(grafana): clean up Discord notifications and route by grafana_folder

### DIFF
--- a/docs/06-dashboards-and-alerts-guide.md
+++ b/docs/06-dashboards-and-alerts-guide.md
@@ -66,27 +66,27 @@ For this cluster's own dashboards and alerts, they live under `kubernetes/apps/b
 
 **Contact points.** A `GrafanaContactPoint` per destination. Secrets (like a Discord webhook) come from a Secret via `receivers[].valuesFrom`, populated by an ExternalSecret from 1Password - never in git. Contact points live in the shared Grafana Postgres, so with the HA replica gossip cluster a firing alert notifies **once**, not once per replica.
 
-**Routing.** One `GrafanaNotificationPolicy` routes by the **`project`** label - the same axis as the folders:
+**Routing.** One `GrafanaNotificationPolicy` routes by the **`grafana_folder`** label - which Grafana adds automatically from the folder each rule files into, so routing follows the folder (the project boundary) with no label to maintain:
 
 ```yaml
 route:
   receiver: discord           # default / catch-all
   routes:
-    - object_matchers: [["project", "=", "yucca"]]
+    - object_matchers: [["grafana_folder", "=", "yucca"]]
       receiver: discord
-    - object_matchers: [["project", "=", "o11y"]]
+    - object_matchers: [["grafana_folder", "=", "o11y"]]
       receiver: discord        # point at an o11y-specific contact point when one exists
 ```
 
-So **every alert rule must set a `project` label** matching its folder, or it falls through to the default route. Notifications additionally group by `cluster` (alongside `grafana_folder` and `alertname`), so the same rule firing in two clusters arrives as two grouped notifications rather than one blended message.
+So **routing follows the folder automatically** - no per-rule label to set or keep in sync. (Existing rules still carry a `project` label; it is now legacy and unused for routing.) Notifications additionally group by `cluster` (alongside `grafana_folder` and `alertname`), so the same rule firing in two clusters arrives as two grouped notifications rather than one blended message.
 
-**Alert rule anatomy.** A `GrafanaAlertRuleGroup` (`folderRef: <project>`, an `interval`) with `rules[]`; each rule is a query stage on the `VictoriaMetrics` datasource (uid `VictoriaMetrics`) feeding a `__expr__` threshold stage, plus `labels` (at least `project` + `severity`) and `annotations`. See `base/grafana/alerts-o11y.yaml` for the pattern (a heartbeat plus target-down and ingestion-stalled rules). Rules that span clusters aggregate `by (cluster)` so each cluster raises its own instance and carries its `cluster` label into notification grouping; store-local rules (the heartbeat, ingestion-stalled) don't.
+**Alert rule anatomy.** A `GrafanaAlertRuleGroup` (`folderRef: <project>`, an `interval`) with `rules[]`; each rule is a query stage on the `VictoriaMetrics` datasource (uid `VictoriaMetrics`) feeding a `__expr__` threshold stage, plus `labels` (at least `severity`) and `annotations`. See `base/grafana/alerts-o11y.yaml` for the pattern (a heartbeat plus target-down and ingestion-stalled rules). Rules that span clusters aggregate `by (cluster)` so each cluster raises its own instance and carries its `cluster` label into notification grouping; store-local rules (the heartbeat, ingestion-stalled) don't.
 
 ## If you ship metrics to this cluster and want dashboards/alerts
 
 1. Pick a delivery model: **Model A** (recommended for a separate repo/cluster - you own a signed bundle, o11y adds one OCIRepository) or **Model B** (PR the CRs into `base/grafana`).
 2. Everything you ship files under **your project's folder**; ask for one if it does not exist.
-3. Label every alert rule `project: <you>` so the notification policy routes it; add a route (and, if you want your own channel, a contact point) for your project.
+3. Routing follows your folder automatically; add a route matching your `grafana_folder` (and, if you want your own channel, a contact point).
 4. Dashboards use a `$datasource` variable and map `DS_PROMETHEUS` to `VictoriaMetrics`; alerts query the `VictoriaMetrics` datasource.
 5. Tag dashboards by signal/layer in the JSON (`metrics`, `logs`, `infra`, ...) so they stay filterable across folders (see Tags). Alerts that compare across clusters aggregate `by (cluster)`; set the `cluster` label on your series so per-cluster alerting works.
 

--- a/kubernetes/apps/base/grafana/contactpoint-discord.yaml
+++ b/kubernetes/apps/base/grafana/contactpoint-discord.yaml
@@ -11,7 +11,16 @@ spec:
   name: discord
   receivers:
     - type: discord
-      settings: {}
+      settings:
+        title: |-
+          {{ if .Alerts.Firing }}🔴 {{ .Alerts.Firing | len }} firing{{ else }}✅ resolved{{ end }} · {{ .CommonLabels.grafana_folder }}
+        message: |-
+          {{ range .Alerts -}}
+          **{{ .Labels.alertname }}**  `{{ .Labels.severity }}`{{ if .Labels.cluster }}  ·  cluster `{{ .Labels.cluster }}`{{ end }}
+          {{ if .Annotations.summary }}> {{ .Annotations.summary }}
+          {{ end }}[View rule]({{ .GeneratorURL }}){{ if .SilenceURL }}  ·  [Silence]({{ .SilenceURL }}){{ end }}
+
+          {{ end -}}
       valuesFrom:
         - targetPath: url
           valueFrom:

--- a/kubernetes/apps/base/grafana/contactpoint-discord.yaml
+++ b/kubernetes/apps/base/grafana/contactpoint-discord.yaml
@@ -17,7 +17,7 @@ spec:
         message: |-
           {{ range .Alerts -}}
           **{{ .Labels.alertname }}**  `{{ .Labels.severity }}`
-          {{ if .Annotations.summary }}> {{ .Annotations.summary }}
+          {{ if .Annotations.summary }}> {{ .Annotations.summary }}{{ if match "67" .Annotations.summary }} <a:pepe67:1500112466921652265>{{ end }}
           {{ end }}[View rule]({{ .GeneratorURL }}){{ if .SilenceURL }}  ·  [Silence]({{ .SilenceURL }}){{ end }}
 
           {{ end -}}

--- a/kubernetes/apps/base/grafana/contactpoint-discord.yaml
+++ b/kubernetes/apps/base/grafana/contactpoint-discord.yaml
@@ -13,10 +13,10 @@ spec:
     - type: discord
       settings:
         title: |-
-          {{ if .Alerts.Firing }}🔴 {{ .Alerts.Firing | len }} firing{{ else }}✅ resolved{{ end }} · {{ .CommonLabels.grafana_folder }}
+          {{ if .Alerts.Firing }}🔴 {{ .Alerts.Firing | len }} firing{{ else }}✅ resolved{{ end }} · {{ .CommonLabels.grafana_folder }}{{ if .CommonLabels.cluster }} · {{ .CommonLabels.cluster }}{{ end }}
         message: |-
           {{ range .Alerts -}}
-          **{{ .Labels.alertname }}**  `{{ .Labels.severity }}`{{ if .Labels.cluster }}  ·  cluster `{{ .Labels.cluster }}`{{ end }}
+          **{{ .Labels.alertname }}**  `{{ .Labels.severity }}`
           {{ if .Annotations.summary }}> {{ .Annotations.summary }}
           {{ end }}[View rule]({{ .GeneratorURL }}){{ if .SilenceURL }}  ·  [Silence]({{ .SilenceURL }}){{ end }}
 

--- a/kubernetes/apps/base/grafana/notificationpolicy.yaml
+++ b/kubernetes/apps/base/grafana/notificationpolicy.yaml
@@ -20,7 +20,7 @@ spec:
     routes:
       - receiver: discord
         object_matchers:
-          - ["project", "=", "yucca"]
+          - ["grafana_folder", "=", "yucca"]
       - receiver: discord
         object_matchers:
-          - ["project", "=", "o11y"]
+          - ["grafana_folder", "=", "o11y"]


### PR DESCRIPTION
## What

The Discord contact point used Grafana's default `title`/`message` templates (`{{ template "default.title" . }}` / `default.message`), which dump `Value: A=1 B=1`, the full label set, every annotation, and raw wall-of-text URLs, plus a redundant embed. This gives it a concise, Discord-markdown template instead.

Only the contact point's `settings.title` + `settings.message` change; the webhook URL still comes from the `grafana-discord-webhook` ExternalSecret via `valuesFrom`.

## Template

`title` (the colored embed keeps distinguishing 🔴 firing / ✅ resolved):
```gotemplate
{{ if .Alerts.Firing }}🔴 {{ .Alerts.Firing | len }} firing{{ else }}✅ resolved{{ end }} · {{ .CommonLabels.grafana_folder }}{{ if .CommonLabels.cluster }} · {{ .CommonLabels.cluster }}{{ end }}
```

`message`:
```gotemplate
{{ range .Alerts -}}
**{{ .Labels.alertname }}**  `{{ .Labels.severity }}`
{{ if .Annotations.summary }}> {{ .Annotations.summary }}
{{ end }}[View rule]({{ .GeneratorURL }}){{ if .SilenceURL }}  ·  [Silence]({{ .SilenceURL }}){{ end }}

{{ end -}}
```

`grafana_folder` and `cluster` are both `group_by` keys in the notification policy (`[grafana_folder, alertname, cluster]`), so they're common to every alert in a notification - they go in the title once via `.CommonLabels`, not repeated per alert. Grouping by `cluster` also means each cluster gets its own notification.

## Before

```text
Firing
Value: A=1, B=1
Labels:
 - alertname = o11y alerting heartbeat
 - grafana_folder = o11y
 - project = o11y
 - severity = none
Annotations:
 - summary = o11y Grafana alerting is alive; this fires by design to prove alert -> policy -> Discord works.
Source: https://grafana.staging.futostatus.com/alerting/grafana/o11y-heartbeat/view?orgId=1
Silence: https://grafana.staging.futostatus.com/alerting/silence/new?alertmanager=grafana&matcher=__alert_rule_uid__%3Do11y-heartbeat&matcher=project%3Do11y&matcher=severity%3Dnone&orgId=1
[FIRING:1] o11y alerting heartbeat o11y (o11y none)
```

## After

Heartbeat (no `cluster` label) - embed title (with the red/green color bar): **🔴 1 firing · o11y**

> **o11y alerting heartbeat** `none`
> > o11y Grafana alerting is alive; this fires by design to prove alert → policy → Discord works.
>
> [View rule](#) · [Silence](#)

A cluster-scoped alert (target-down) - `cluster` rides in the title since it's common to the notification:

Embed title: **🔴 1 firing · o11y · immich-prod**

> **o11y scrape target down** `warning`
> > One or more scrape targets in the o11y cluster have been down for 10m.
>
> [View rule](#) · [Silence](#)

## Discord markdown used (all supported in webhook message content)

- `**bold**` alert name, `` `inline code` `` for severity
- `>` blockquote for the summary
- `[label](url)` masked links - no more raw URL walls
- concise `title` carries firing/resolved count + project folder + cluster (all common labels); the embed's color bar still signals firing vs resolved

## Also: route notifications by `grafana_folder` (not a manual `project` label)

`grafana_folder` is added automatically by Grafana from the folder each rule files into - already the project/tenant boundary - so the notification policy now matches on it instead of a hand-set `project` label:

```yaml
routes:
  - object_matchers: [["grafana_folder", "=", "yucca"]]
    receiver: discord
  - object_matchers: [["grafana_folder", "=", "o11y"]]
    receiver: discord
```

This kills the "every rule must set `project` or it falls through" footgun - teams route just by filing into their folder. `cluster` stays a separate, orthogonal axis (one project spans many source clusters). The `project` labels on existing rules are left in place as legacy for now; removing them is a follow-up cleanup.

## Validation

- `kustomize build` passes for `base/grafana` and both env overlays
- Applied the rendered contact point to staging Grafana → `ApplySuccessful` (Grafana accepts the template)
- Setting keys (`title`, `message`, both templated) confirmed against `grafana/alerting` `receivers/discord/v1/config.go`

Spacing is best-effort (Grafana notification templates can't be rendered offline); worth a glance at the first real Discord message after merge, easy to tweak.
