### PR TITLE
fix(grafana): consolidate the Discord alert into a single embed

### DIFF
--- a/kubernetes/apps/base/grafana/contactpoint-discord.yaml
+++ b/kubernetes/apps/base/grafana/contactpoint-discord.yaml
@@ -12,11 +12,12 @@ spec:
   receivers:
     - type: discord
       settings:
+        use_embed_description: true
         title: |-
           {{ if .Alerts.Firing }}🔴 {{ .Alerts.Firing | len }} firing{{ else }}✅ resolved{{ end }} · {{ .CommonLabels.grafana_folder }}{{ if .CommonLabels.cluster }} · {{ .CommonLabels.cluster }}{{ end }}
         message: |-
           {{ range .Alerts -}}
-          **{{ .Labels.alertname }}**  `{{ .Labels.severity }}`
+          **{{ .Labels.alertname }}**{{ if and .Labels.severity (ne .Labels.severity "none") }}  `{{ .Labels.severity }}`{{ end }}
           {{ if .Annotations.summary }}> {{ .Annotations.summary }}{{ if match "67" .Annotations.summary }} <a:pepe67:1500112466921652265>{{ end }}
           {{ end }}[View rule]({{ .GeneratorURL }}){{ if .SilenceURL }}  ·  [Silence]({{ .SilenceURL }}){{ end }}
 


### PR DESCRIPTION
## What

Grafana's Discord notifier **always** attaches exactly one embed (color bar + a hardcoded `Grafana vX` footer + the rule link) - it can't send zero. Previously the alert rendered as message content *above* that embed, leaving an awkward "text, then a small stub card" split.

Setting `use_embed_description: true` folds the message into the embed's description, so it's one clean colored card: firing/resolved count + folder (+ cluster) as the title, the alert details as the body, the color bar down the side.

Also hides the severity chip when severity is `none` or unset - the heartbeat is `severity: none`, which was rendering a literal `none` chip. Real severities (`warning`/`critical`) still show.

## Changes

- `use_embed_description: true` on the Discord contact point.
- Severity chip guarded so it only shows for a real severity:

```gotemplate
**{{ .Labels.alertname }}**{{ if and .Labels.severity (ne .Labels.severity "none") }}  `{{ .Labels.severity }}`{{ end }}
```

## Notes

- Zero embeds isn't achievable with the Grafana Discord contact-point type (the notifier unconditionally builds one embed for the color + footer), so the move is to make that one embed *be* the whole message.
- No link-preview embeds either: `[View rule]` / `[Silence]` are masked links, which don't unfurl.

## Validation

- `kustomize build` passes for `base/grafana` and both env overlays.
- Applied the rendered contact point to staging (`-n o11y`) → `ApplySuccessful` (Grafana accepts `use_embed_description`).
