### PR TITLE
feat(grafana): replace heartbeat with core infrastructure and delivery alerts

### DIFF
--- a/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
+++ b/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
@@ -451,3 +451,223 @@ spec:
                 reducer:
                   type: last
                   params: []
+    - uid: o11y-grafana-notif-failing
+      title: o11y Grafana notification delivery failing
+      condition: B
+      for: 0s
+      labels:
+        project: o11y
+        severity: critical
+      annotations:
+        summary: Grafana in {{ $labels.cluster }} failed to deliver one or more alert notifications in the last 15m; check the contact point and Discord webhook.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: sum by (cluster) (increase(grafana_alerting_notifications_failed_total[15m])) > 0
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: gt
+                  params: [0]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-postgres-primary-count
+      title: o11y grafana-postgres primary count off
+      condition: B
+      for: 5m
+      labels:
+        project: o11y
+        severity: critical
+      annotations:
+        summary: grafana-postgres in {{ $labels.cluster }} does not have exactly one primary; the cluster may be headless or split-brain.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: sum by (cluster) (1 - cnpg_pg_replication_in_recovery)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: outside_range
+                  params: [0.5, 1.5]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-postgres-standbys-detached
+      title: o11y grafana-postgres standby detached
+      condition: B
+      for: 15m
+      labels:
+        project: o11y
+        severity: warning
+      annotations:
+        summary: grafana-postgres in {{ $labels.cluster }} has fewer than 2 standbys streaming from the primary; HA is degraded.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: max by (cluster) (cnpg_pg_replication_streaming_replicas)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: lt
+                  params: [2]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-postgres-replication-lag
+      title: o11y grafana-postgres replication lag
+      condition: B
+      for: 15m
+      labels:
+        project: o11y
+        severity: warning
+      annotations:
+        summary: grafana-postgres standby {{ $labels.pod }} in {{ $labels.cluster }} is more than 5m behind the primary.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: max by (cluster, pod) (cnpg_pg_replication_lag)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: gt
+                  params: [300]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []

--- a/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
+++ b/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
@@ -11,61 +11,6 @@ spec:
   folderRef: o11y
   interval: 1m
   rules:
-    - uid: o11y-heartbeat
-      title: o11y alerting heartbeat
-      condition: B
-      for: 0s
-      labels:
-        project: o11y
-        severity: none
-      annotations:
-        summary: o11y Grafana alerting is alive; this fires by design to prove alert -> policy -> Discord works.
-      execErrState: Error
-      noDataState: NoData
-      data:
-        - refId: A
-          datasourceUid: VictoriaMetrics
-          queryType: ""
-          relativeTimeRange:
-            from: 600
-            to: 0
-          model:
-            refId: A
-            datasource:
-              type: prometheus
-              uid: VictoriaMetrics
-            expr: vector(1)
-            instant: true
-            range: false
-            intervalMs: 1000
-            maxDataPoints: 43200
-        - refId: B
-          datasourceUid: __expr__
-          queryType: ""
-          relativeTimeRange:
-            from: 600
-            to: 0
-          model:
-            refId: B
-            type: threshold
-            datasource:
-              type: __expr__
-              uid: __expr__
-            expression: A
-            intervalMs: 1000
-            maxDataPoints: 43200
-            conditions:
-              - type: query
-                evaluator:
-                  type: gt
-                  params: [0]
-                operator:
-                  type: and
-                query:
-                  params: [A]
-                reducer:
-                  type: last
-                  params: []
     - uid: o11y-target-down
       title: o11y scrape target down
       condition: B
@@ -169,6 +114,336 @@ spec:
                 evaluator:
                   type: lt
                   params: [1]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-logs-ingestion-stalled
+      title: o11y logs ingestion stalled
+      condition: B
+      for: 10m
+      labels:
+        project: o11y
+        severity: warning
+      annotations:
+        summary: VictoriaLogs ingestion in the o11y cluster is under 1 row/s for 10m; the logs pipeline may be stalled.
+      execErrState: Error
+      noDataState: NoData
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: sum(rate(vl_rows_ingested_total[5m]))
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: lt
+                  params: [1]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-cluster-silent
+      title: o11y cluster stopped reporting
+      condition: B
+      for: 15m
+      labels:
+        project: o11y
+        severity: critical
+      annotations:
+        summary: Cluster {{ $labels.cluster }} reported metrics within the last day but has sent nothing recently; its remote write path may be down.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: count by (cluster) (up offset 1d) unless count by (cluster) (up)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: gt
+                  params: [0]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-node-not-ready
+      title: o11y node not ready
+      condition: B
+      for: 5m
+      labels:
+        project: o11y
+        severity: critical
+      annotations:
+        summary: Node {{ $labels.node }} in {{ $labels.cluster }} is not Ready.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: min by (cluster, node) (kube_node_status_condition{condition="Ready",status="true"})
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: lt
+                  params: [1]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-pvc-low-space
+      title: o11y volume almost full
+      condition: B
+      for: 15m
+      labels:
+        project: o11y
+        severity: critical
+      annotations:
+        summary: PVC {{ $labels.namespace }}/{{ $labels.persistentvolumeclaim }} in {{ $labels.cluster }} has less than 10% free space.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: min by (cluster, namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: lt
+                  params: [0.1]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-pod-crashlooping
+      title: o11y pod crashlooping
+      condition: B
+      for: 5m
+      labels:
+        project: o11y
+        severity: warning
+      annotations:
+        summary: Pod {{ $labels.namespace }}/{{ $labels.pod }} in {{ $labels.cluster }} restarted more than 5 times in the last hour.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: sum by (cluster, namespace, pod) (increase(kube_pod_container_status_restarts_total[1h])) > 5
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: gt
+                  params: [0]
+                operator:
+                  type: and
+                query:
+                  params: [A]
+                reducer:
+                  type: last
+                  params: []
+    - uid: o11y-cert-renewal-overdue
+      title: o11y certificate renewal overdue
+      condition: B
+      for: 30m
+      labels:
+        project: o11y
+        severity: warning
+      annotations:
+        summary: Certificate {{ $labels.exported_namespace }}/{{ $labels.name }} in {{ $labels.cluster }} is more than 6h past its scheduled renewal; cert-manager may be failing to renew it.
+      execErrState: Error
+      noDataState: OK
+      data:
+        - refId: A
+          datasourceUid: VictoriaMetrics
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: A
+            datasource:
+              type: prometheus
+              uid: VictoriaMetrics
+            expr: max by (cluster, name, exported_namespace) (time() - certmanager_certificate_renewal_timestamp_seconds)
+            instant: true
+            range: false
+            intervalMs: 1000
+            maxDataPoints: 43200
+        - refId: B
+          datasourceUid: __expr__
+          queryType: ""
+          relativeTimeRange:
+            from: 600
+            to: 0
+          model:
+            refId: B
+            type: threshold
+            datasource:
+              type: __expr__
+              uid: __expr__
+            expression: A
+            intervalMs: 1000
+            maxDataPoints: 43200
+            conditions:
+              - type: query
+                evaluator:
+                  type: gt
+                  params: [21600]
                 operator:
                   type: and
                 query:

--- a/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
+++ b/kubernetes/apps/base/grafana/app/alerts-o11y.yaml
@@ -34,7 +34,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: count(up == 0) by (cluster)
+            expr: count(up{cluster="${CLUSTER_NAME}"} == 0) by (cluster)
             instant: true
             range: false
             intervalMs: 1000
@@ -89,7 +89,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: sum(rate(vm_rows_inserted_total[5m]))
+            expr: sum(rate(vm_rows_inserted_total{cluster="${CLUSTER_NAME}"}[5m]))
             instant: true
             range: false
             intervalMs: 1000
@@ -144,7 +144,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: sum(rate(vl_rows_ingested_total[5m]))
+            expr: sum(rate(vl_rows_ingested_total{cluster="${CLUSTER_NAME}"}[5m]))
             instant: true
             range: false
             intervalMs: 1000
@@ -254,7 +254,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: min by (cluster, node) (kube_node_status_condition{condition="Ready",status="true"})
+            expr: min by (cluster, node) (kube_node_status_condition{cluster="${CLUSTER_NAME}",condition="Ready",status="true"})
             instant: true
             range: false
             intervalMs: 1000
@@ -309,7 +309,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: min by (cluster, namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes)
+            expr: min by (cluster, namespace, persistentvolumeclaim) (kubelet_volume_stats_available_bytes{cluster="${CLUSTER_NAME}"} / kubelet_volume_stats_capacity_bytes{cluster="${CLUSTER_NAME}"})
             instant: true
             range: false
             intervalMs: 1000
@@ -364,7 +364,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: sum by (cluster, namespace, pod) (increase(kube_pod_container_status_restarts_total[1h])) > 5
+            expr: sum by (cluster, namespace, pod) (increase(kube_pod_container_status_restarts_total{cluster="${CLUSTER_NAME}"}[1h])) > 5
             instant: true
             range: false
             intervalMs: 1000
@@ -419,7 +419,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: max by (cluster, name, exported_namespace) (time() - certmanager_certificate_renewal_timestamp_seconds)
+            expr: max by (cluster, name, exported_namespace) (time() - certmanager_certificate_renewal_timestamp_seconds{cluster="${CLUSTER_NAME}"})
             instant: true
             range: false
             intervalMs: 1000
@@ -474,7 +474,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: sum by (cluster) (increase(grafana_alerting_notifications_failed_total[15m])) > 0
+            expr: sum by (cluster) (increase(grafana_alerting_notifications_failed_total{cluster="${CLUSTER_NAME}"}[15m])) > 0
             instant: true
             range: false
             intervalMs: 1000
@@ -529,7 +529,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: sum by (cluster) (1 - cnpg_pg_replication_in_recovery)
+            expr: sum by (cluster) (1 - cnpg_pg_replication_in_recovery{cluster="${CLUSTER_NAME}"})
             instant: true
             range: false
             intervalMs: 1000
@@ -584,7 +584,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: max by (cluster) (cnpg_pg_replication_streaming_replicas)
+            expr: max by (cluster) (cnpg_pg_replication_streaming_replicas{cluster="${CLUSTER_NAME}"})
             instant: true
             range: false
             intervalMs: 1000
@@ -639,7 +639,7 @@ spec:
             datasource:
               type: prometheus
               uid: VictoriaMetrics
-            expr: max by (cluster, pod) (cnpg_pg_replication_lag)
+            expr: max by (cluster, pod) (cnpg_pg_replication_lag{cluster="${CLUSTER_NAME}"})
             instant: true
             range: false
             intervalMs: 1000

--- a/kubernetes/apps/base/grafana/app/kustomization.yaml
+++ b/kubernetes/apps/base/grafana/app/kustomization.yaml
@@ -7,5 +7,6 @@ resources:
   - ./datasource.yaml
   - ./contactpoint-discord.yaml
   - ./notificationpolicy.yaml
+  - ./servicemonitor.yaml
   - ./alerts-o11y.yaml
   - ./dashboards

--- a/kubernetes/apps/base/grafana/app/servicemonitor.yaml
+++ b/kubernetes/apps/base/grafana/app/servicemonitor.yaml
@@ -1,0 +1,13 @@
+---
+# yaml-language-server: $schema=https://k8s-schemas.home-operations.com/monitoring.coreos.com/servicemonitor_v1.json
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: grafana
+spec:
+  selector:
+    matchLabels:
+      dashboards: grafana
+  endpoints:
+    - port: grafana
+      path: /metrics


### PR DESCRIPTION
## What

Replaces the proven-and-now-noisy heartbeat alert with a set of core alerts, adds a Grafana metrics scrape, and scopes everything to this cluster's label.

### Alert group changes (`o11y` folder)

Removed:
- **o11y alerting heartbeat** - it proved the alert -> policy -> Discord path end to end; a heartbeat is only useful when something alarms on its absence. It returns as a dead man's switch once we pick an external provider.

Added (kept: target-down, metrics-ingestion-stalled):
| Rule | Severity | Fires when |
|---|---|---|
| logs ingestion stalled | warning | VictoriaLogs under 1 row/s for 10m |
| cluster stopped reporting | critical | a cluster seen in the last day sends nothing for 15m |
| node not ready | critical | Ready != true for 5m |
| volume almost full | critical | PVC under 10% free for 15m |
| pod crashlooping | warning | >5 restarts in 1h |
| certificate renewal overdue | warning | 6h+ past cert-manager's renewal point for 30m |
| Grafana notification delivery failing | critical | any failed notification in 15m |
| grafana-postgres primary count off | critical | not exactly one primary for 5m |
| grafana-postgres standby detached | warning | <2 streaming standbys for 15m |
| grafana-postgres replication lag | warning | standby >5m behind for 15m |

### Grafana scrape

Grafana itself was not scraped (only grafana-postgres and the operator), so there was no delivery signal at all. Added a ServiceMonitor for the operator-managed `grafana-service` (prometheus-operator CR per repo convention; the VM operator converts it). Verified `/metrics` serves unauthenticated and exposes `grafana_alerting_notifications_(failed_)total{integration="discord"}`.

### Cluster scoping

All rules filter on `cluster="${CLUSTER_NAME}"` (per-env Flux substitution) since remote clusters will carry their own alert definitions. Exception: **cluster stopped reporting** stays unscoped on purpose - a dead cluster cannot alert on itself, so the central o11y Grafana owns that detection.

## Notes

- Every expression was validated live against staging and production vmselect; all return healthy values today and none false-fire.
- The envoy certs are short-lived (~2-day renewal cycle), so the cert alert is renewal-relative; an expiry-window threshold would fire permanently.
- Remote clusters ship partial metric sets (father/netops: kubelet volume stats only; spice: neither) - per-cluster rules extend automatically as they ship more.
- Verified `flux envsubst` leaves the unbraced `$labels` Grafana templates untouched while substituting `${CLUSTER_NAME}`.
- Known gap: if Grafana/the cluster is down entirely, nothing fires - that's the external dead man's switch, pending provider choice.